### PR TITLE
build: Build movement-controller image in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,21 +49,21 @@ undeploy:
 
 .PHONY: docker
 docker:
-	$(MAKE) -C build docker-dummy-mover
+	$(MAKE) -C build all
 	$(MAKE) -C manager docker-all
 	$(MAKE) -C secret-provider docker-all
 	$(MAKE) -C connectors docker-all
 
 .PHONY: docker-build
 docker-build:
-	$(MAKE) -C build docker-build-dummy-mover
+	$(MAKE) -C build docker-build-all
 	$(MAKE) -C manager docker-build
 	$(MAKE) -C secret-provider docker-build
 	$(MAKE) -C connectors docker-build
 
 .PHONY: docker-push
 docker-push:
-	$(MAKE) -C build docker-push-dummy-mover
+	$(MAKE) -C build docker-push-all
 	$(MAKE) -C manager docker-push
 	$(MAKE) -C secret-provider docker-push
 	$(MAKE) -C connectors docker-push

--- a/build/Makefile
+++ b/build/Makefile
@@ -10,9 +10,7 @@ IMG_MC ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/movement-controller:${DOCKER_TA
 IMG_DM ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/dummy-mover:${DOCKER_TAGNAME}
 
 .PHONY: all
-all: docker-movement-controller docker-build-dummy-mover
-	$(MAKE) docker-push IMG=$(IMG_MC)
-	$(MAKE) docker-push IMG=$(IMG_DM)
+all: docker-build-all docker-push-all
 
 .PHONY: docker-build-all
 docker-build-all: docker-movement-controller docker-build-dummy-mover

--- a/build/Makefile
+++ b/build/Makefile
@@ -10,7 +10,15 @@ IMG_MC ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/movement-controller:${DOCKER_TA
 IMG_DM ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/dummy-mover:${DOCKER_TAGNAME}
 
 .PHONY: all
-all: docker-movement-controller docker-dummy-mover
+all: docker-movement-controller docker-build-dummy-mover
+	$(MAKE) docker-push IMG=$(IMG_MC)
+	$(MAKE) docker-push IMG=$(IMG_DM)
+
+.PHONY: docker-build-all
+docker-build-all: docker-movement-controller docker-build-dummy-mover
+
+.PHONY: docker-push-all
+docker-push-all:
 	$(MAKE) docker-push IMG=$(IMG_MC)
 	$(MAKE) docker-push IMG=$(IMG_DM)
 


### PR DESCRIPTION
This PR will always build the movement-controller image that is used in some demos.