### PR TITLE
deploy: Dynamic namespaces

### DIFF
--- a/manager/Makefile
+++ b/manager/Makefile
@@ -26,14 +26,14 @@ docker-build: generate
 
 # Deploy only movement-controller in the configured Kubernetes cluster in ~/.kube/config
 deploy_mc: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl
-	$(TOOLBIN)/kubectl create namespace m4d-system || true
+	$(TOOLBIN)/kubectl create namespace ${DOCKER_NAMESPACE} || true
 	cd config/manager && $(ABSTOOLBIN)/kustomize edit set image controller=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/movement-controller:${DOCKER_TAGNAME}
-	$(TOOLBIN)/kustomize build --load_restrictor none config/movement-controller | $(TOOLBIN)/kubectl apply -f -
+	cd config/movement-controller && $(ABSTOOLBIN)/kustomize edit set namespace ${DOCKER_NAMESPACE}
+	$(TOOLBIN)/kustomize build --load_restrictor none config/movement-controller | $(TOOLBIN)/kubectl apply --namespace=${DOCKER_NAMESPACE} -f -
 
 undeploy_mc: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl
-	$(TOOLBIN)/kubectl create namespace m4d-system || true
 	cd config/manager && $(ABSTOOLBIN)/kustomize edit set image controller=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/movement-controller:${DOCKER_TAGNAME}
-	$(TOOLBIN)/kustomize build --load_restrictor none config/movement-controller | $(TOOLBIN)/kubectl delete -f -
+	$(TOOLBIN)/kustomize build --load_restrictor none config/movement-controller | $(TOOLBIN)/kubectl delete --namespace=${DOCKER_NAMESPACE} -f -
 
 .PHONY: motion-integration-tests
 motion-integration-tests: #deploy_mc

--- a/manager/config/manager/manager.yaml
+++ b/manager/config/manager/manager.yaml
@@ -1,12 +1,6 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -35,7 +29,7 @@ spec:
           - name: ENABLE_WEBHOOKS
             value: "true"
           - name: MOVER_IMAGE
-            value: "image-registry.openshift-image-registry.svc:5000/mover/mover:1.0-SNAPSHOT"
+            value: "image-registry.openshift-image-registry.svc:5000/the-mesh-for-data/mover:latest"
           - name: IMAGE_PULL_POLICY
             value: "Always"
         resources:

--- a/manager/config/movement-controller/kustomization.yaml
+++ b/manager/config/movement-controller/kustomization.yaml
@@ -2,36 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Adds namespace to all resources.
-namespace: m4d-system
+namespace: the-mesh-for-data
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: m4d
+namePrefix: m4d-
 
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
-- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
 #- ../prometheus
 
-patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-- ../default/manager_auth_proxy_patch.yaml
-- ../default/manager_secret_provider_patch.yaml
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, uncomment the following line and
   # comment manager_auth_proxy_patch.yaml.
@@ -40,39 +31,52 @@ patchesStrategicMerge:
 #- manager_prometheus_metrics_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
-- ../default/manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
+patchesStrategicMerge:
+- ../default/manager_auth_proxy_patch.yaml
+- ../default/manager_secret_provider_patch.yaml
+- ../default/manager_webhook_patch.yaml
 - ../default/webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: CERTIFICATE_NAMESPACE
   objref:
-    kind: Certificate
     group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
     version: v1alpha2
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
+- fieldref: {}
+  name: CERTIFICATE_NAME
   objref:
-    kind: Certificate
     group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
     version: v1alpha2
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
+- fieldref:
+    fieldPath: metadata.namespace
+  name: SERVICE_NAMESPACE
   objref:
     kind: Service
-    version: v1
     name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
+    version: v1
+- fieldref: {}
+  name: SERVICE_NAME
   objref:
     kind: Service
-    version: v1
     name: webhook-service
+    version: v1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager


### PR DESCRIPTION
This PR gets rid of the default m4d-system namespace. It's created twice currently. Once by kubectl create ns and once by from its definition in the yaml. 
The proposal is to only create it using kubectl create ns so that it can be changed dynamically to the value of `DOCKER_NAMESPACE`. That way e.g. when building and deploying to openshift the image will be in the correct openshift project. 
CAUTION: This will change the default namespace from `m4d-system` to `the-mesh-for-data` as this is the namespace that we're publishing the images to.