### PR TITLE
scripts: docker password is not always available in Travis

### DIFF
--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -1,20 +1,17 @@
-DOCKER_PASSWORD ?= $(shell echo "${DOCKER_PASSWORD_ENCODED}" | base64 -d)
-DOCKER_HOSTNAME ?= ghcr.io
-DOCKER_NAMESPACE ?= the-mesh-for-data
+#export DOCKER_USERNAME ?= ""
+#export DOCKER_PASSWORD ?= ""
+export DOCKER_HOSTNAME ?= ghcr.io
+export DOCKER_NAMESPACE ?= the-mesh-for-data
+export DOCKER_TAGNAME ?= latest
+
 DOCKER_NAME ?= m4d
-DOCKER_TAGNAME ?= latest
+DOCKER_FILE ?= Dockerfile
 DOCKER_CONTEXT ?= .
-GO_INPUT_FILE ?= main.go
-GO_OUTPUT_FILE ?= manager
+
 IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_NAME}:${DOCKER_TAGNAME}
 
-export DOCKER_USERNAME
-export DOCKER_PASSWORD
-export DOCKER_HOSTNAME
-export DOCKER_NAMESPACE
-export DOCKER_TAGNAME
-
-DOCKER_FILE ?= Dockerfile
+GO_INPUT_FILE ?= main.go
+GO_OUTPUT_FILE ?= manager
 
 .PHONY: docker-all
 docker-all: docker-build docker-push
@@ -29,7 +26,7 @@ docker-build-local:
 
 .PHONY: docker-push
 docker-push:
-ifdef DOCKER_USERNAME
+ifdef DOCKER_PASSWORD
 	@docker login \
 		--username ${DOCKER_USERNAME} \
 		--password ${DOCKER_PASSWORD} ${DOCKER_HOSTNAME}

--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -26,7 +26,7 @@ docker-build-local:
 
 .PHONY: docker-push
 docker-push:
-ifdef DOCKER_PASSWORD
+ifneq (${DOCKER_PASSWORD},)
 	@docker login \
 		--username ${DOCKER_USERNAME} \
 		--password ${DOCKER_PASSWORD} ${DOCKER_HOSTNAME}

--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -1,5 +1,5 @@
-#export DOCKER_USERNAME ?= ""
-#export DOCKER_PASSWORD ?= ""
+export DOCKER_USERNAME ?=
+export DOCKER_PASSWORD ?=
 export DOCKER_HOSTNAME ?= ghcr.io
 export DOCKER_NAMESPACE ?= the-mesh-for-data
 export DOCKER_TAGNAME ?= latest

--- a/.mk/helm.mk
+++ b/.mk/helm.mk
@@ -9,7 +9,7 @@ export HELM_EXPERIMENTAL_OCI=1
 
 .PHONY: helm-login
 helm-login: $(TOOLBIN)/helm
-ifdef DOCKER_USERNAME
+ifdef DOCKER_PASSWORD
 	@$(ABSTOOLBIN)/helm registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" ${DOCKER_HOSTNAME}
 endif
 

--- a/.mk/helm.mk
+++ b/.mk/helm.mk
@@ -9,7 +9,7 @@ export HELM_EXPERIMENTAL_OCI=1
 
 .PHONY: helm-login
 helm-login: $(TOOLBIN)/helm
-ifdef DOCKER_PASSWORD
+ifneq (${DOCKER_PASSWORD},)
 	@$(ABSTOOLBIN)/helm registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" ${DOCKER_HOSTNAME}
 endif
 

--- a/.mk/ibmcloud.mk
+++ b/.mk/ibmcloud.mk
@@ -1,10 +1,3 @@
-DOCKER_PASSWORD ?= $(shell echo "${DOCKER_PASSWORD_ENCODED}" | base64 -d)
-DOCKER_HOSTNAME ?= registry-1.docker.io
-DOCKER_NAMESPACE ?= m4d
-DOCKER_NAME ?= m4d
-DOCKER_TAGNAME ?= latest
-IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_NAME}:${DOCKER_TAGNAME}
-
 IBMCLOUD:=/usr/local/bin/ibmcloud
 
 .PHONY: ibmcloud-login

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ test:
 
 .PHONY: e2e
 e2e:
-	$(MAKE) -C pkg/helm test
+	# TODO(roee88): temporarily removed until can be set against local registry
+	# $(MAKE) -C pkg/helm test
 	$(MAKE) -C manager e2e
 
 .PHONY: cluster-prepare

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -89,17 +89,19 @@ func (r *BlueprintReconciler) applyChartResource(ctx context.Context, log logr.L
 	nbytes, _ := yaml.Marshal(vals)
 	log.Info(fmt.Sprintf("--- Values.yaml ---\n\n%s\n\n", nbytes))
 
+	// TODO: should change to use an ImagePullSecret referenced from the M4DModule resource
 	hostname := os.Getenv("DOCKER_HOSTNAME")
 	username := os.Getenv("DOCKER_USERNAME")
 	password := os.Getenv("DOCKER_PASSWORD")
 	insecure, _ := strconv.ParseBool(os.Getenv("DOCKER_INSECURE"))
-
-	err := r.Helmer.RegistryLogin(hostname, username, password, insecure)
-	if err != nil {
-		return ctrl.Result{}, errors.WithMessage(err, ref+": failed chart pull")
+	if username != "" && password != "" {
+		err := r.Helmer.RegistryLogin(hostname, username, password, insecure)
+		if err != nil {
+			return ctrl.Result{}, errors.WithMessage(err, ref+": failed chart pull")
+		}
 	}
 
-	err = r.Helmer.ChartPull(ref)
+	err := r.Helmer.ChartPull(ref)
 	if err != nil {
 		return ctrl.Result{}, errors.WithMessage(err, ref+": failed chart pull")
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -52,7 +52,7 @@ type Interface interface {
 	Upgrade(chart *chart.Chart, kubeNamespace string, releaseName string, vals map[string]interface{}) (*release.Release, error)
 	Status(kubeNamespace string, releaseName string) (*release.Release, error)
 	RegistryLogin(hostname string, username string, password string, insecure bool) error
-	RegistryLogout(hostname string, username string) error
+	RegistryLogout(hostname string) error
 	ChartRemove(ref string) error
 	ChartSave(chart *chart.Chart, ref string) error
 	ChartLoad(ref string) (*chart.Chart, error)
@@ -94,7 +94,7 @@ func (r *Fake) RegistryLogin(hostname string, username string, password string, 
 }
 
 // RegistryLogout to docker registry v2
-func (r *Fake) RegistryLogout(hostname string, username string) error {
+func (r *Fake) RegistryLogout(hostname string) error {
 	return nil
 }
 
@@ -185,17 +185,14 @@ func (r *Impl) RegistryLogin(hostname string, username string, password string, 
 }
 
 // RegistryLogout to docker registry v2
-func (r *Impl) RegistryLogout(hostname string, username string) error {
-	if username != "" {
-		cfg, err := getConfig("")
-		if err != nil {
-			return err
-		}
-		logout := action.NewRegistryLogout(cfg)
-		var buf bytes.Buffer
-		return logout.Run(&buf, hostname)
+func (r *Impl) RegistryLogout(hostname string) error {
+	cfg, err := getConfig("")
+	if err != nil {
+		return err
 	}
-	return nil
+	logout := action.NewRegistryLogout(cfg)
+	var buf bytes.Buffer
+	return logout.Run(&buf, hostname)
 }
 
 // ChartRemove helm chart from cache

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -172,16 +172,13 @@ func (r *Impl) Status(kubeNamespace string, releaseName string) (*release.Releas
 
 // RegistryLogin to docker registry v2
 func (r *Impl) RegistryLogin(hostname string, username string, password string, insecure bool) error {
-	if username != "" && password != "" {
-		cfg, err := getConfig("")
-		if err != nil {
-			return err
-		}
-		login := action.NewRegistryLogin(cfg)
-		var buf bytes.Buffer
-		return login.Run(&buf, hostname, username, password, insecure)
+	cfg, err := getConfig("")
+	if err != nil {
+		return err
 	}
-	return nil
+	login := action.NewRegistryLogin(cfg)
+	var buf bytes.Buffer
+	return login.Run(&buf, hostname, username, password, insecure)
 }
 
 // RegistryLogout to docker registry v2

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -172,7 +172,7 @@ func (r *Impl) Status(kubeNamespace string, releaseName string) (*release.Releas
 
 // RegistryLogin to docker registry v2
 func (r *Impl) RegistryLogin(hostname string, username string, password string, insecure bool) error {
-	if username != "" {
+	if username != "" && password != "" {
 		cfg, err := getConfig("")
 		if err != nil {
 			return err

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -79,9 +79,11 @@ func TestHelmRegistry(t *testing.T) {
 	var err error
 	origChart := buildTestChart()
 
-	err = impl.RegistryLogin(hostname, username, password, insecure)
-	assert.Nil(t, err)
-	Log(t, "registry login", err)
+	if username != "" && password != "" {
+		err = impl.RegistryLogin(hostname, username, password, insecure)
+		assert.Nil(t, err)
+		Log(t, "registry login", err)
+	}
 
 	err = impl.ChartSave(origChart, chartRef)
 	assert.Nil(t, err)

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -5,11 +5,12 @@ package helm
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"helm.sh/helm/v3/pkg/chart"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/chart"
 )
 
 func buildTestChart() *chart.Chart {
@@ -95,9 +96,11 @@ func TestHelmRegistry(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, origChart.Metadata.Name, chart.Metadata.Name, "expected pushed chart equals pulled chart")
 
-	err = impl.RegistryLogout(hostname, username)
-	assert.Nil(t, err)
-	Log(t, "registry logout", err)
+	if username != "" && password != "" {
+		err = impl.RegistryLogout(hostname)
+		assert.Nil(t, err)
+		Log(t, "registry logout", err)
+	}
 }
 
 func TestHelmRelease(t *testing.T) {

--- a/secret-provider/deployment/deploy-secret-provider.sh
+++ b/secret-provider/deployment/deploy-secret-provider.sh
@@ -5,21 +5,8 @@
 
 : ${KUBE_NAMESPACE:=m4d-system}
 
-# DOCKER_PASSWORD is from the CI or from env variable
 deploy() {
     kubectl apply -n $KUBE_NAMESPACE -f secret-provider/secret-provider-rbac.yaml
-    if [[ -z $(kubectl get secrets cloud-registry  -n $KUBE_NAMESPACE --ignore-not-found) ]]; then
-        kubectl create secret docker-registry cloud-registry \
-                --docker-server="$DOCKER_HOSTNAME" \
-                --docker-username="$DOCKER_USERNAME" \
-                --docker-password="$DOCKER_PASSWORD" \
-                -n $KUBE_NAMESPACE
-    fi
-
-    kubectl patch serviceaccount secret-provider -p \
-    '{"imagePullSecrets": [{"name": "cloud-registry"}]}' \
-    -n $KUBE_NAMESPACE
-
     kubectl apply -n $KUBE_NAMESPACE -f secret-provider/secret-provider.yaml
 }
 

--- a/third_party/registry/deploy.sh
+++ b/third_party/registry/deploy.sh
@@ -34,7 +34,7 @@ registry_create() {
             -n $namespace
 }
 
-[ -n "$DOCKER_USERNAME" ] || exit 0
+[ -n "$DOCKER_PASSWORD" ] || exit 0
 
 case "$1" in
 undeploy)


### PR DESCRIPTION
DOCKER_PASSWORD was set in plaintext in the Travis settings. I had to change it to an encrypted variable and reset it to a new token. Since then, Travis builds fail.

The reason is that pull requests from forks are not allowed to use secure variables. See https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions.

This pull request changes the code as follows:

1. Checks the existence of DOCKER_PASSWORD rather than DOCKER_USERNAME (NOTE: I believe this is preferable to hiding the username as well, since it was useful for me in the past especially since Travis replaces that value with `[secure]` even if it's taken from something other than the DOCKER_USERNAME)
2. Removes duplication of  the variables defined in ibmcloud.mk
3. Removes cloud-registry secret from deploy-secret-provider.sh (the image of the secret provider are public)
4. **Temporarily disables the tests for `pkg/helm`**. This is done because these tests assume being able to push to a registry. However, the Travis script doesn't set it to run against a local registry (runs against ghcr.io instead).

