### PR TITLE
changing m4dapplication for e2e

### DIFF
--- a/manager/testdata/e2e/m4dapplication.yaml
+++ b/manager/testdata/e2e/m4dapplication.yaml
@@ -20,12 +20,4 @@ spec:
       ifDetails:
         protocol: m4d-arrow-flight
         dataformat: arrow
-    - dataSetID: '{"asset_id": "yyy", "catalog_id": "s3"}'
-      ifDetails:
-        protocol: m4d-arrow-flight
-        dataformat: arrow
-    - dataSetID: '{"asset_id": "zzz", "catalog_id": "db2"}'
-      ifDetails:
-        protocol: m4d-arrow-flight
-        dataformat: arrow
 


### PR DESCRIPTION
CI fails when encountering a conflict in assigning bucket ownership to multiple assets in a single m4dapplication. In a long term, we'll allocate a new bucket dynamically, in a not so long term, we will attempt several reconciliations in case of errors. For now, modifying a test s.t. CI won't fail on e2e test. 