### PR TITLE
Speedup docker builds by cross-compiling go binaries local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,6 +185,7 @@ jobs:
     - make $CLUSTER || travis_terminate 1;
     - make cluster-prepare || travis_terminate 1;
     - make -C $COMPONENT deploy
+    - kubectl get pod --all-namespaces
     if: branch = master AND type = push
 
   - stage: Deploy
@@ -199,6 +200,7 @@ jobs:
     - make $CLUSTER || travis_terminate 1;
     - make cluster-prepare || travis_terminate 1;
     - make -C $COMPONENT deploy
+    - kubectl get pod --all-namespaces
     if: branch = master AND type = push
 
   - stage: Deploy
@@ -214,6 +216,7 @@ jobs:
     - make cluster-prepare || travis_terminate 1;
     - make -C third_party/opa deploy || travis_terminate 1;
     - make -C $COMPONENT deploy
+    - kubectl get pod --all-namespaces
     if: branch = master AND type = push
 
 notifications:

--- a/build/Makefile
+++ b/build/Makefile
@@ -22,7 +22,7 @@ docker-push-all:
 
 .PHONY: docker-movement-controller
 docker-movement-controller:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager ../cmd/movement-controller/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager ../cmd/movement-controller/main.go
 	docker build . -t $(IMG_MC) -f Dockerfile.movement-controller
 	(rm manager || true)
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -24,7 +24,7 @@ docker-push-all:
 docker-movement-controller:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager ../cmd/movement-controller/main.go
 	docker build . -t $(IMG_MC) -f Dockerfile.movement-controller
-	(rm manager || true)
+	rm manager
 
 .PHONY: docker-dummy-mover
 docker-dummy-mover:

--- a/connectors/egeria/Makefile
+++ b/connectors/egeria/Makefile
@@ -7,7 +7,7 @@ include $(ROOT_DIR)/.mk/docker.mk
 
 .PHONY: build
 build:
-	mvn clean install -DskipTests
+	mvn clean package -DskipTests
 
 docker-build: build
 

--- a/connectors/opa/Dockerfile
+++ b/connectors/opa/Dockerfile
@@ -1,17 +1,6 @@
-#FROM golang:1.13.8
-FROM golang:1.13.8-alpine
+FROM gcr.io/distroless/static:nonroot
 
-WORKDIR /m4d/
-COPY go.mod go.mod
-
-COPY pkg/connectors/protobuf pkg/connectors/protobuf
-
-WORKDIR /m4d/connectors/opa
-COPY connectors/opa .
-
-RUN go get -v ./...
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o opa-connector *.go
+COPY opa-connector /opa-connector
 
 EXPOSE 50082
 

--- a/connectors/opa/Makefile
+++ b/connectors/opa/Makefile
@@ -8,6 +8,11 @@ include $(ROOT_DIR)/.mk/docker.mk
 OPA_PATH=${ABSTOOLBIN}/opa
 OPA_DEFAULT_POLICY_FILE=${ROOT_DIR}/third_party/opa/opa-policy.rego
 
+docker-build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o opa-connector opa_connector.go evaluate_opa.go
+	docker build . -t $(IMG) -f Dockerfile
+	(rm opa-connector || true)
+
 .PHONY: opaserver
 opaserver:
 	{ $(OPA_PATH) run --server $(OPA_DEFAULT_POLICY_FILE) > output-opa.log 2>&1 & echo $$! >> opa_pids.txt; }

--- a/connectors/opa/Makefile
+++ b/connectors/opa/Makefile
@@ -11,7 +11,7 @@ OPA_DEFAULT_POLICY_FILE=${ROOT_DIR}/third_party/opa/opa-policy.rego
 docker-build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o opa-connector opa_connector.go evaluate_opa.go
 	docker build . -t $(IMG) -f Dockerfile
-	(rm opa-connector || true)
+	rm opa-connector
 
 .PHONY: opaserver
 opaserver:

--- a/connectors/vault/Dockerfile
+++ b/connectors/vault/Dockerfile
@@ -1,18 +1,6 @@
-#FROM golang:1.13.8
-FROM golang:1.13.8-alpine
+FROM gcr.io/distroless/static:nonroot
 
-WORKDIR /m4d/
-COPY go.mod go.mod
-
-WORKDIR /m4d/pkg/connectors/
-COPY pkg/connectors/protobuf protobuf
-
-WORKDIR /m4d/connectors/vault
-COPY connectors/vault .
-
-RUN go get -v ./...
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o vault-connector *.go
+COPY vault-connector /vault-connector
 
 EXPOSE 50083
 

--- a/connectors/vault/Makefile
+++ b/connectors/vault/Makefile
@@ -9,6 +9,11 @@ include $(ROOT_DIR)/.mk/docker.mk
 VAULT_PATH=${ABSTOOLBIN}/vault
 include $(ROOT_DIR)/pkg/policy-compiler/policy-compiler.env
 
+docker-build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o vault-connector vault_connector.go vault_utils.go
+	docker build . -t $(IMG) -f Dockerfile
+	(rm vault-connector || true)
+
 .PHONY: vaultserver-clean
 vaultserver-clean:
 	rm -f output-vault.log && rm -f output-vault-init.log

--- a/connectors/vault/Makefile
+++ b/connectors/vault/Makefile
@@ -12,7 +12,7 @@ include $(ROOT_DIR)/pkg/policy-compiler/policy-compiler.env
 docker-build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o vault-connector vault_connector.go vault_utils.go
 	docker build . -t $(IMG) -f Dockerfile
-	(rm vault-connector || true)
+	rm vault-connector
 
 .PHONY: vaultserver-clean
 vaultserver-clean:

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -23,6 +23,7 @@ build-linux: generate vet
 docker-build: generate
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
 	docker build . -t ${IMG} -f Dockerfile
+	rm manager
 
 # Deploy only movement-controller in the configured Kubernetes cluster in ~/.kube/config
 deploy_mc: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -21,7 +21,7 @@ build-linux: generate vet
 
 # Overwrite docker-build from docker.mk
 docker-build: generate
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
 	docker build . -t ${IMG} -f Dockerfile
 
 # Deploy only movement-controller in the configured Kubernetes cluster in ~/.kube/config


### PR DESCRIPTION
Building the connector docker containers currently takes 5 minutes as it loads the whole directory into the docker context (which is then almost 1GB) and needs to download a golang environment and compile it in a docker container. Then the compiled file is just added to the image resulting in an image that is 588MB.

This new method builds the binaries directly and copies them into an empty docker container. Resulting in an image that is around 17MB and a build time that is multiples faster. 