### PR TITLE
pkg: Fix mac compatibility

### DIFF
--- a/pkg/policy-compiler/Makefile
+++ b/pkg/policy-compiler/Makefile
@@ -30,7 +30,7 @@ clean:
 policy-compiler-test:
 	go test ./... -coverprofile=coverage.out
 	go tool cover -func=coverage.out
-	go tool cover -html=coverage.out
+	#go tool cover -html=coverage.out
 
 .PHONY: test
 test: policy-compiler-test

--- a/pkg/policy-compiler/pc-bl/policy_compiler_test.go
+++ b/pkg/policy-compiler/pc-bl/policy_compiler_test.go
@@ -129,8 +129,8 @@ func TestMain(m *testing.M) {
 	tu.EnvValues["MAIN_POLICY_MANAGER_URL"] = "localhost:" + "40081"
 	tu.EnvValues["EXTENSIONS_POLICY_MANAGER_URL"] = "localhost:" + "40091"
 
-	go tu.MockMainConnector("40081")
-	go tu.MockExtConnector("40091")
+	go tu.MockMainConnector(40081)
+	go tu.MockExtConnector(40091)
 	code := m.Run()
 	fmt.Println("TestMain function called after Run = policy_compiler_test ")
 	os.Exit(code)

--- a/pkg/policy-compiler/policy-compiler/policy_compiler_server_test.go
+++ b/pkg/policy-compiler/policy-compiler/policy_compiler_server_test.go
@@ -55,8 +55,8 @@ func TestMain(m *testing.M) {
 	tu.EnvValues["MAIN_POLICY_MANAGER_URL"] = "localhost:" + "40082"
 	tu.EnvValues["EXTENSIONS_POLICY_MANAGER_URL"] = "localhost:" + "40092"
 
-	go tu.MockMainConnector("40082")
-	go tu.MockExtConnector("40092")
+	go tu.MockMainConnector(40082)
+	go tu.MockExtConnector(40092)
 	code := m.Run()
 	fmt.Println("TestMain function called after Run = policy_compiler_server_test ")
 	os.Exit(code)

--- a/pkg/policy-compiler/testutil/helper.go
+++ b/pkg/policy-compiler/testutil/helper.go
@@ -6,6 +6,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"github.com/ibm/the-mesh-for-data/manager/controllers/utils"
 	"log"
 	"net"
 	"strconv"
@@ -183,10 +184,11 @@ func (s *connectorMockMain) GetPoliciesDecisions(ctx context.Context, in *pb.App
 	return GetMainPMDecisions(in.GetAppInfo().GetPurpose()), nil
 }
 
-func MockMainConnector(port string) {
-	log.Println("Start Mock for Main PolicyConnector at port " + port)
+func MockMainConnector(port int) {
+	address := utils.ListeningAddress(port)
+	log.Println("Start Mock for Main PolicyConnector at " + address)
 
-	lis, err := net.Listen("tcp", ":"+port)
+	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatalf("Error in listening: %v", err)
 	}
@@ -229,10 +231,11 @@ func (s *connectorMockExt) GetPoliciesDecisions(ctx context.Context, in *pb.Appl
 	return GetExtPMDecisions(in.GetAppInfo().GetPurpose()), nil
 }
 
-func MockExtConnector(port string) {
-	log.Println("Start Mock for Extension PolicyConnector at port " + port)
+func MockExtConnector(port int) {
+	address := utils.ListeningAddress(port)
+	log.Println("Start Mock for Extension PolicyConnector at port " + address)
 
-	lis, err := net.Listen("tcp", ":"+port)
+	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatalf("Error in listening: %v", err)
 	}


### PR DESCRIPTION
This PR prohibits the OS X firewall popups when running the tests.

I also disabled the coverage tool. It forces the browser to open the generated html file. Does anyone know if it produces useful information that is used by Travis CI or github? @roee88 @hunchback ?