### PR TITLE
travis: Remove fmt and vet from `make test`

### DIFF
--- a/.mk/operator.mk
+++ b/.mk/operator.mk
@@ -7,7 +7,7 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 all: manager
 
 # Run tests
-test: generate fmt vet manifests
+test: generate manifests
 	go test ./... -coverprofile cover.out
 
 # Build manager binary


### PR DESCRIPTION
Removes the fmt and vet commands from `make test`. This is already covered by travis in `make verify`