### PR TITLE
checking standard resources of a Helm release

### DIFF
--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -279,7 +279,7 @@ func (r *BlueprintReconciler) checkResourceStatus(res *unstructured.Unstructured
 		// Failed status indicates a failure
 		computedResult, err := kstatus.Compute(res)
 		if err != nil {
-			r.Log.V(0).Info("Error computing the status of " + res.GetKind() + " : " + err.Error()
+			r.Log.V(0).Info("Error computing the status of " + res.GetKind() + " : " + err.Error())
 			return corev1.ConditionUnknown, ""
 		}
 		switch computedResult.Status {

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -277,7 +277,11 @@ func (r *BlueprintReconciler) checkResourceStatus(res *unstructured.Unstructured
 		// use kstatus to compute the status of the resources for them the expected results have not been specified
 		// Current status of a deployed release indicates that the resource has been successfully reconciled
 		// Failed status indicates a failure
-		computedResult, _ := kstatus.Compute(res)
+		computedResult, err := kstatus.Compute(res)
+		if err != nil {
+			r.Log.V(0).Info("Error computing the status of " + res.GetKind() + " : " + err.Error()
+			return corev1.ConditionUnknown, ""
+		}
 		switch computedResult.Status {
 		case kstatus.FailedStatus:
 			return corev1.ConditionFalse, computedResult.Message

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ibm/the-mesh-for-data/pkg/helm"
 	corev1 "k8s.io/api/core/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
 // BlueprintReconciler reconciles a Blueprint object
@@ -273,8 +274,18 @@ func (r *BlueprintReconciler) checkResourceStatus(res *unstructured.Unstructured
 		return corev1.ConditionUnknown, ""
 	}
 	if expected == nil {
-		// TODO: use kstatus to compute the status of the resources for them the expected results have not been specified
-		return corev1.ConditionTrue, ""
+		// use kstatus to compute the status of the resources for them the expected results have not been specified
+		// Current status of a deployed release indicates that the resource has been successfully reconciled
+		// Failed status indicates a failure
+		computedResult, _ := kstatus.Compute(res)
+		switch computedResult.Status {
+		case kstatus.FailedStatus:
+			return corev1.ConditionFalse, computedResult.Message
+		case kstatus.CurrentStatus:
+			return corev1.ConditionTrue, ""
+		default:
+			return corev1.ConditionUnknown, ""
+		}
 	}
 	// use expected values to compute the status
 	if r.matchesCondition(res, expected.SuccessCondition) {
@@ -324,7 +335,7 @@ func (r *BlueprintReconciler) checkReleaseStatus(releaseName string, namespace s
 	numReady := 0
 	for _, res := range resources {
 		state, errMsg := r.checkResourceStatus(res)
-		r.Log.V(0).Info("Status of " + releaseName + " is " + string(state))
+		r.Log.V(0).Info("Status of " + res.GetKind() + " " + res.GetName() + " is " + string(state))
 		if state == corev1.ConditionFalse {
 			return state, errMsg
 		}


### PR DESCRIPTION
Fixes https://github.com/IBM/the-mesh-for-data/issues/27
This PR checks status of standard resources, such as Deployment, to provide a more accurate readiness status to the user.

make e2e -C manager
```
Status of ServiceAccount r310a550dcff7f408dc38-arrow-flight-module is True
Status of ConfigMap r310a550dcff7f408dc38-arrow-flight-module is True
Status of Service r310a550dcff7f408dc38-arrow-flight-module is True
Status of Deployment r310a550dcff7f408dc38-arrow-flight-module is Unknown
blueprint reconcile cycle completed	{"blueprint": "m4d-7h7hk/notebook", "result": {"Requeue":false,"RequeueAfter":2000000000}}
```
...

```
Status of ServiceAccount r310a550dcff7f408dc38-arrow-flight-module is True
Status of ConfigMap r310a550dcff7f408dc38-arrow-flight-module is True
Status of Service r310a550dcff7f408dc38-arrow-flight-module is True
Status of Deployment r310a550dcff7f408dc38-arrow-flight-module is True
blueprint reconcile cycle completed	{"blueprint": "m4d-7h7hk/notebook", "result": {"Requeue":false,"RequeueAfter":0}}

```