### PR TITLE
fixing the installation script

### DIFF
--- a/connectors/helpers/base/egr_connector.yaml
+++ b/connectors/helpers/base/egr_connector.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app: egr-connector
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -4,9 +4,9 @@ set -e
 
 : ${KUBE_NAMESPACE:=m4d-system}
 : ${PORT_TO_FORWARD:=8200}
-: ${WITHOUT_VAULT=false}
-: ${WITHOUT_EGERIA=false}
-: ${WITHOUT_OPA=false}
+: ${WITHOUT_VAULT:=false}
+: ${WITHOUT_EGERIA:=false}
+: ${WITHOUT_OPA:=false}
 
 source third_party/vault/vault-util.sh
 
@@ -17,9 +17,9 @@ kubectl apply -f manager/config/prod/deployment_configmap.yaml -n $KUBE_NAMESPAC
 make cluster-prepare
 
 # Install third party components
-WITHOUT_VAULT || make -C third_party/vault deploy
-WITHOUT_EGERIA || make -C third_party/egeria deploy
-WITHOUT_OPA || make -C third_party/opa deploy
+$WITHOUT_VAULT || make -C third_party/vault deploy
+$WITHOUT_EGERIA || make -C third_party/egeria deploy
+$WITHOUT_OPA || make -C third_party/opa deploy
 
 # Waiting for the vault deployment to become ready
 make -C third_party/vault wait_for_vault

--- a/third_party/egeria/deploy.sh
+++ b/third_party/egeria/deploy.sh
@@ -33,6 +33,9 @@ deploy() {
             --filter=blob:none \
             https://github.com/odpi/egeria.git
 
+        # create the ns if it doesn't exist
+        kubectl create ns $NAMESPACE || true
+
         # scc permissions for egeria pods to execute
         # this is done as per guidelines mentioned in https://github.com/odpi/egeria/issues/2790#issuecomment-674879248 
         $WITHOUT_OPENSHIFT || oc create -f egeria-scc.yaml
@@ -42,7 +45,7 @@ deploy() {
         helm dep update $chartpath
         helm install $RELEASE $chartpath \
             -f lab.yaml \
-            --namespace=$NAMESPACE --create-namespace \
+            --namespace=$NAMESPACE \
             --wait --timeout=${TIMEOUT}
 
         rm -rf egeria

--- a/third_party/vault/Makefile
+++ b/third_party/vault/Makefile
@@ -11,4 +11,5 @@ undeploy:
 	./deploy.sh undeploy
 
 .PHONY: wait_for_vault
+wait_for_vault:
 	./deploy.sh wait_for_vault

--- a/third_party/vault/vault-util.sh
+++ b/third_party/vault/vault-util.sh
@@ -138,6 +138,7 @@ wait_for_vault() {
 # Do port-forwarding, if needed
 port_forward() {
   # Port forward, so we could access vault
+  echo "Creating a port-forward from $PORT_TO_FORWARD to 8200 for Vault"
   kubectl port-forward -n $KUBE_NAMESPACE service/vault "$PORT_TO_FORWARD":8200 &
   while ! nc -z localhost "$PORT_TO_FORWARD"; do echo "Waiting for the port-forward from $PORT_TO_FORWARD to 8200 to take effect"; sleep 1; done
 }


### PR DESCRIPTION
Fixed the install.sh script to use correctly the `WITHOUT_X` environment variables. Also fixed Vault's Makefile (it's a miracle it worked before, probably b/c we didn't need to wait for Vault b/c Egeria's deployment takes very long time).

Also fixed the number of Egeria connector instances to be 1 (was 3 before for no good reason).

Also fixed Egeria's installation script - didn't work properly on OpenShift.
Previously, due to a bug, the script was relying on the existence of the `egeria-catalog` in order to work properly.


