### PR TITLE
add AssetID to read arguments inside a blueprint

### DIFF
--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -31,6 +31,11 @@ type ReadModuleArgs struct {
 	// +required
 	Source DataStore `json:"source"`
 
+	// AssetName represents the asset name to be used for accessing the data when it is ready
+	// It is copied from the m4dapplication
+	// +required
+	AssetName string `json:"assetName"`
+
 	// Transformations are different types of processing that may be done to the data
 	// +optional
 	Transformations []pb.EnforcementAction `json:"transformations,omitempty"`

--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -32,7 +32,7 @@ type ReadModuleArgs struct {
 	Source DataStore `json:"source"`
 
 	// AssetName represents the asset name to be used for accessing the data when it is ready
-	// It is copied from the m4dapplication resource
+	// It is copied from the M4DApplication resource
 	// +required
 	AssetName string `json:"assetName"`
 

--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -32,7 +32,7 @@ type ReadModuleArgs struct {
 	Source DataStore `json:"source"`
 
 	// AssetName represents the asset name to be used for accessing the data when it is ready
-	// It is copied from the m4dapplication
+	// It is copied from the m4dapplication resource
 	// +required
 	AssetName string `json:"assetName"`
 

--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -31,10 +31,10 @@ type ReadModuleArgs struct {
 	// +required
 	Source DataStore `json:"source"`
 
-	// AssetName represents the asset name to be used for accessing the data when it is ready
+	// AssetID identifies the asset to be used for accessing the data when it is ready
 	// It is copied from the M4DApplication resource
 	// +required
-	AssetName string `json:"assetName"`
+	AssetID string `json:"assetID"`
 
 	// Transformations are different types of processing that may be done to the data
 	// +optional

--- a/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
@@ -221,7 +221,7 @@ spec:
                               description: ReadModuleArgs define the input parameters for modules that read data from location A
                               properties:
                                 assetName:
-                                  description: AssetName represents the asset name to be used for accessing the data when it is ready It is copied from the m4dapplication
+                                  description: AssetName represents the asset name to be used for accessing the data when it is ready It is copied from the m4dapplication resource
                                   type: string
                                 source:
                                   description: Source of the read path module

--- a/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
@@ -221,7 +221,7 @@ spec:
                               description: ReadModuleArgs define the input parameters for modules that read data from location A
                               properties:
                                 assetName:
-                                  description: AssetName represents the asset name to be used for accessing the data when it is ready It is copied from the m4dapplication resource
+                                  description: AssetName represents the asset name to be used for accessing the data when it is ready It is copied from the M4DApplication resource
                                   type: string
                                 source:
                                   description: Source of the read path module

--- a/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
@@ -220,6 +220,9 @@ spec:
                             items:
                               description: ReadModuleArgs define the input parameters for modules that read data from location A
                               properties:
+                                assetName:
+                                  description: AssetName represents the asset name to be used for accessing the data when it is ready It is copied from the m4dapplication
+                                  type: string
                                 source:
                                   description: Source of the read path module
                                   properties:
@@ -307,6 +310,7 @@ spec:
                                     type: object
                                   type: array
                               required:
+                              - assetName
                               - source
                               type: object
                             type: array

--- a/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
@@ -220,8 +220,8 @@ spec:
                             items:
                               description: ReadModuleArgs define the input parameters for modules that read data from location A
                               properties:
-                                assetName:
-                                  description: AssetName represents the asset name to be used for accessing the data when it is ready It is copied from the M4DApplication resource
+                                assetID:
+                                  description: AssetID identifies the asset to be used for accessing the data when it is ready It is copied from the M4DApplication resource
                                   type: string
                                 source:
                                   description: Source of the read path module
@@ -310,7 +310,7 @@ spec:
                                     type: object
                                   type: array
                               required:
-                              - assetName
+                              - assetID
                               - source
                               type: object
                             type: array

--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -196,7 +196,7 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 	var requirements []modules.DataInfo
 	for _, dataset := range applicationContext.Spec.Data {
 		req := modules.DataInfo{
-			AssetID:      utils.CreateDataSetIdentifier(dataset.DataSetID),
+			AssetID:      dataset.DataSetID,
 			DataDetails:  nil,
 			Credentials:  nil,
 			Actions:      make(map[app.ModuleFlow]modules.Transformations),

--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -183,7 +183,7 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 	readInstructions := make([]app.ReadModuleArgs, 0)
 	readInstructions = append(readInstructions, app.ReadModuleArgs{
 		Source:          readSource,
-		AssetName:       item.AssetID,
+		AssetID:         item.AssetID,
 		Transformations: actionsOnRead.EnforcementActions})
 	readArgs := &app.ModuleArguments{
 		Flow: app.Read,

--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -183,6 +183,7 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 	readInstructions := make([]app.ReadModuleArgs, 0)
 	readInstructions = append(readInstructions, app.ReadModuleArgs{
 		Source:          readSource,
+		AssetName:       item.AssetID,
 		Transformations: actionsOnRead.EnforcementActions})
 	readArgs := &app.ModuleArguments{
 		Flow: app.Read,


### PR DESCRIPTION
This PR adds a new field **assetID**  inside read module arguments in a blueprint.
This argument identifies an asset that can be used  by a read module for creating data access instructions 
as **"{{ .Values.assetID}}"**

```
    - arguments:
        flow:  read
        read:
          - assetID: {"asset_id": "xxx", "catalog_id": "s3"}
            source:
              connection:
                name:  cos
                s3:
                  bucket:           m4d-test-bucket
                  endpoint:         s3.eu-gb.cloud-object-storage.appdomain.cloud
                  object_key:       small.parq
               ...
      name:            notebook-arrow-flight-module-{"asset_id": "xxx", "catalog_id": "s3"}
      template:        arrow-flight-module

```