### PR TITLE
Don't set image pull policy by default

### DIFF
--- a/modules/m4d-db2wh/templates/batchtransfer.yaml
+++ b/modules/m4d-db2wh/templates/batchtransfer.yaml
@@ -27,8 +27,10 @@ spec:
   - name: "Remove columns"
     action: "RemoveColumns"
     columns: ["JOB", "SSN"]
-  secretProviderURL: "http://secret-provider.secret-provider.svc.cluster.local:5555/get-secret"
-  secretProviderRole: demo
-  image: ghcr.io/the-mesh-for-data/mover:latest
-  imagePullPolicy: "IfNotPresent"
-  noFinalizer: true
+  {{ if .Values.image }}
+  image: {{ .Values.image | quote }}
+  {{ end }}
+  {{ if .Values.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+  {{ end }}
+  noFinalizer: {{ .Values.noFinalizer }}

--- a/modules/m4d-db2wh/values.yaml
+++ b/modules/m4d-db2wh/values.yaml
@@ -11,6 +11,10 @@ metadata:
   namespace: "default"
   labels: []
 
+image: "ghcr.io/the-mesh-for-data/mover:latest"
+imagePullPolicy: null
+noFinalizer: "false"
+
 # copies from source
 source:
   connection:

--- a/modules/m4d-kafka/templates/streamtransfer.yaml
+++ b/modules/m4d-kafka/templates/streamtransfer.yaml
@@ -40,9 +40,10 @@ spec:
     action: "RemoveColumns"
     columns: ["Latitude","Longitude"]
   triggerInterval: "10 seconds"
-  image: ghcr.io/the-mesh-for-data/mover:latest
-  imagePullPolicy: "IfNotPresent"
-  secretProviderURL: "http://secret-provider.secret-provider.svc.cluster.local:5555/get-secret"
-  secretProviderRole: demo
-  column_name: column_value
-  noFinalizer: true
+  {{ if .Values.image }}
+  image: {{ .Values.image | quote }}
+  {{ end }}
+  {{ if .Values.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+  {{ end }}
+  noFinalizer: {{ .Values.noFinalizer }}

--- a/modules/m4d-kafka/values.yaml
+++ b/modules/m4d-kafka/values.yaml
@@ -11,6 +11,10 @@ metadata:
   namespace: "default"
   labels: []
 
+image: "ghcr.io/the-mesh-for-data/mover:latest"
+imagePullPolicy: null
+noFinalizer: "false"
+
 # copies from source
 source:
   connection:

--- a/modules/m4d-s3-to-s3/values.yaml
+++ b/modules/m4d-s3-to-s3/values.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: []
 
 image: "ghcr.io/the-mesh-for-data/mover:latest"
-imagePullPolicy: "IfNotPresent"
+imagePullPolicy: null
 noFinalizer: "false"
 
 # copies from source


### PR DESCRIPTION
This PR does not set the imagePullPolicy by default. 
Like this the manager can set the imagePullPolicy when defaulting BatchTransfer and StreamTransfer.

The current policy is IfNotPresent which will reuse images that are already downloaded in a cluster. When updating the image behind the tag (Currently we're still using latest) this will result in still using the old image.

Like this the installation of the-mesh-for-data decides the policy.