### PR TITLE
Fix destination format

### DIFF
--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -180,8 +180,11 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 
 	// Data User created or updated the M4DApplication
 
-	// clear conditions
+	// clear status
 	applicationContext.Status.Conditions = make([]app.Condition, 0)
+	applicationContext.Status.DataAccessInstructions = ""
+	applicationContext.Status.Ready = false
+
 	key, _ := client.ObjectKeyFromObject(applicationContext)
 
 	// clear storage assets

--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -33,7 +33,7 @@ func InitM4DApplication(n int) *apiv1alpha1.M4DApplication {
 			Name:      appSignature.Name,
 			Namespace: appSignature.Namespace,
 		},
-		Spec: apiv1alpha1.M4DApplicationSpec{Data: make([]apiv1alpha1.DataContext, n)},
+		Spec: apiv1alpha1.M4DApplicationSpec{AppInfo: apiv1alpha1.ApplicationDetails{ProcessingGeography: "US"}, Data: make([]apiv1alpha1.DataContext, n)},
 	}
 }
 

--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -52,7 +52,7 @@ func StructToInterfaceDetails(item modules.DataInfo) (*app.InterfaceDetails, err
 // These buckets are allocated during deployment of the control plane.
 // If there are no free buckets the creation of the runtime environment for the application will fail.
 // TODO - In the future need to implement dynamic provisioning of buckets for implicit copy.
-func (r *M4DApplicationReconciler) GetCopyDestination(item modules.DataInfo, appContext *app.M4DApplication, appInterface *app.InterfaceDetails) *app.DataStore {
+func (r *M4DApplicationReconciler) GetCopyDestination(item modules.DataInfo, appContext *app.M4DApplication, destinationInterface *app.InterfaceDetails) *app.DataStore {
 	// provisioned storage for COPY
 	objectKey, _ := client.ObjectKeyFromObject(appContext)
 	originalAssetName := item.DataDetails.Name
@@ -72,7 +72,7 @@ func (r *M4DApplicationReconciler) GetCopyDestination(item modules.DataInfo, app
 				ObjectKey: bucket.Status.AssetPrefixPerDataset[item.AssetID],
 			},
 		},
-		Format: string(appInterface.DataFormat),
+		Format: string(destinationInterface.DataFormat),
 	}
 }
 
@@ -126,6 +126,9 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 	r.Log.V(0).Info("Checking supported read sources")
 	sources := GetSupportedReadSources(readSelector.GetModule())
 	utils.PrintStructure(sources, r.Log, "Read sources")
+	// logic for deciding whether copy module is required
+	// In some cases copy is required to perform transformations at source
+	// Temporary solution: in these cases mark copy actions as required until rules for transformations at data source are implemented in policy manager
 	if !utils.SupportsInterface(sources, source) || item.Actions[app.Copy].Required {
 		r.Log.V(0).Info("Copy is required for " + item.AssetID)
 		// is copy allowed?

--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -52,7 +52,7 @@ func StructToInterfaceDetails(item modules.DataInfo) (*app.InterfaceDetails, err
 // These buckets are allocated during deployment of the control plane.
 // If there are no free buckets the creation of the runtime environment for the application will fail.
 // TODO - In the future need to implement dynamic provisioning of buckets for implicit copy.
-func (r *M4DApplicationReconciler) GetCopyDestination(item modules.DataInfo, appContext *app.M4DApplication) *app.DataStore {
+func (r *M4DApplicationReconciler) GetCopyDestination(item modules.DataInfo, appContext *app.M4DApplication, appInterface *app.InterfaceDetails) *app.DataStore {
 	// provisioned storage for COPY
 	objectKey, _ := client.ObjectKeyFromObject(appContext)
 	originalAssetName := item.DataDetails.Name
@@ -72,7 +72,7 @@ func (r *M4DApplicationReconciler) GetCopyDestination(item modules.DataInfo, app
 				ObjectKey: bucket.Status.AssetPrefixPerDataset[item.AssetID],
 			},
 		},
-		Format: string(item.AppInterface.DataFormat),
+		Format: string(appInterface.DataFormat),
 	}
 }
 
@@ -126,7 +126,7 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 	r.Log.V(0).Info("Checking supported read sources")
 	sources := GetSupportedReadSources(readSelector.GetModule())
 	utils.PrintStructure(sources, r.Log, "Read sources")
-	if !utils.SupportsInterface(sources, source) {
+	if !utils.SupportsInterface(sources, source) || item.Actions[app.Copy].Required {
 		r.Log.V(0).Info("Copy is required for " + item.AssetID)
 		// is copy allowed?
 		actionsOnCopy := item.Actions[app.Copy]
@@ -157,7 +157,7 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 		}
 		r.Log.V(0).Info("Found copy module " + copySelector.GetModule().Name)
 		// copy should be applied - allocate storage
-		sinkDataStore = r.GetCopyDestination(item, appContext)
+		sinkDataStore = r.GetCopyDestination(item, appContext, copySelector.Destination)
 		if sinkDataStore == nil {
 			return instances
 		}

--- a/manager/controllers/app/modules/moduleinterface.go
+++ b/manager/controllers/app/modules/moduleinterface.go
@@ -16,7 +16,10 @@ type Transformations struct {
 	EnforcementActions []pb.EnforcementAction
 	Message            string
 	Reason             string
-	Required           bool
+
+	// In some cases copy is required to perform transformations at source
+	// Temporary solution: in these cases mark copy actions as required until rules for transformations at data source are implemented in policy manager
+	Required bool
 }
 
 // DataInfo defines all the information about the given data set

--- a/manager/controllers/app/modules/moduleinterface.go
+++ b/manager/controllers/app/modules/moduleinterface.go
@@ -16,6 +16,7 @@ type Transformations struct {
 	EnforcementActions []pb.EnforcementAction
 	Message            string
 	Reason             string
+	Required           bool
 }
 
 // DataInfo defines all the information about the given data set

--- a/manager/controllers/mockup/mockup_catalog_connector.go
+++ b/manager/controllers/mockup/mockup_catalog_connector.go
@@ -30,6 +30,7 @@ func (s *server) GetDatasetInfo(ctx context.Context, in *pb.CatalogDatasetReques
 			Details: &pb.DatasetDetails{
 				Name:       "xxx",
 				DataFormat: "parquet",
+				Geo:        "US",
 				DataStore: &pb.DataStore{
 					Type: pb.DataStore_S3,
 					Name: "cos",
@@ -48,6 +49,7 @@ func (s *server) GetDatasetInfo(ctx context.Context, in *pb.CatalogDatasetReques
 			Details: &pb.DatasetDetails{
 				Name:       "yyy",
 				DataFormat: "table",
+				Geo:        "US",
 				DataStore: &pb.DataStore{
 					Type: pb.DataStore_DB2,
 					Name: "db2",
@@ -68,6 +70,7 @@ func (s *server) GetDatasetInfo(ctx context.Context, in *pb.CatalogDatasetReques
 			Details: &pb.DatasetDetails{
 				Name:       "Cars",
 				DataFormat: "json",
+				Geo:        "US",
 				DataStore: &pb.DataStore{
 					Type: pb.DataStore_KAFKA,
 					Name: "kafka",
@@ -92,6 +95,7 @@ func (s *server) GetDatasetInfo(ctx context.Context, in *pb.CatalogDatasetReques
 		Details: &pb.DatasetDetails{
 			Name:       "yyy",
 			DataFormat: "table",
+			Geo:        "US",
 			DataStore: &pb.DataStore{
 				Type: pb.DataStore_DB2,
 				Name: "db2",


### PR DESCRIPTION
This PR provides the following fixes and enhancements:
- The format for data destination was wrongly selected from the application interface instead from the chosen model capability.
- In case of different locations (data residency and processing geography) when transformations are requires, manager selects implicit copy module to perform the transformations before reading the data. This is a temporary work-around until a full decision logic is implemented, based on the policy compiler response. 