### PR TITLE
revisit module structure and yamls

### DIFF
--- a/manager/Makefile
+++ b/manager/Makefile
@@ -93,6 +93,7 @@ e2e-cleanup: $(TOOLBIN)/kubectl
 	killall -9 datacatalogstub 2>/dev/null || true
 	@echo
 	@echo "deleting resources..."
+	$(ABSTOOLBIN)/kubectl delete -f testdata/e2e/module-implicit-copy-s3-to-s3.yaml || true
 	$(ABSTOOLBIN)/kubectl delete -f testdata/e2e/module-implicit-copy-db2wh-to-s3.yaml || true
 	$(ABSTOOLBIN)/kubectl delete -f testdata/e2e/module-implicit-copy-kafka-to-s3-stream.yaml || true
 	$(ABSTOOLBIN)/kubectl patch m4dapplication notebook -p '{"metadata":{"finalizers":[]}}' --type=merge || true
@@ -121,6 +122,7 @@ e2e-setup: $(TOOLBIN)/kubectl
 	@echo
 	$(MAKE) install
 	@echo "creating resources..."
+	$(ABSTOOLBIN)/kubectl apply -f testdata/e2e/module-implicit-copy-s3-to-s3.yaml
 	$(ABSTOOLBIN)/kubectl apply -f testdata/e2e/module-implicit-copy-db2wh-to-s3.yaml
 	$(ABSTOOLBIN)/kubectl apply -f testdata/e2e/module-implicit-copy-kafka-to-s3-stream.yaml
 	$(ABSTOOLBIN)/kubectl apply -f testdata/e2e/bucket-available.yaml

--- a/manager/apis/app/v1alpha1/m4dmodule_types.go
+++ b/manager/apis/app/v1alpha1/m4dmodule_types.go
@@ -144,13 +144,6 @@ type ResourceStatusIndicator struct {
 // which are one of the components that process, load, write, audit, monitor the data used by
 // the data scientist's application.
 type M4DModuleSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// ModuleType indicates one of job, service, configuration so the manager knows how to deploy it
-	// +required
-	Type ComponentType `json:"type"`
-
 	// Flows is a list of the types of capabilities supported by the module - copy, read, write
 	// +required
 	Flows []ModuleFlow `json:"flows"`

--- a/manager/config/crd/bases/app.m4d.ibm.com_m4dmodules.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_m4dmodules.yaml
@@ -206,18 +206,10 @@ spec:
                 - successCondition
                 type: object
               type: array
-            type:
-              description: ModuleType indicates one of job, service, configuration so the manager knows how to deploy it
-              enum:
-              - job
-              - service
-              - configuration
-              type: string
           required:
           - capabilities
           - chart
           - flows
-          - type
           type: object
       required:
       - spec

--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -45,7 +45,6 @@ func CreateReadPathModule() *apiv1alpha1.M4DModule {
 			Namespace: "default",
 		},
 		Spec: apiv1alpha1.M4DModuleSpec{
-			Type:  apiv1alpha1.Service,
 			Flows: []apiv1alpha1.ModuleFlow{apiv1alpha1.Read},
 			Capabilities: apiv1alpha1.Capability{
 				CredentialsManagedBy: apiv1alpha1.SecretProvider,
@@ -70,7 +69,6 @@ func CreateKafkaToS3CopyModule() *apiv1alpha1.M4DModule {
 			Namespace: "default",
 		},
 		Spec: apiv1alpha1.M4DModuleSpec{
-			Type:  apiv1alpha1.Service,
 			Flows: []apiv1alpha1.ModuleFlow{apiv1alpha1.Copy},
 			Capabilities: apiv1alpha1.Capability{
 				CredentialsManagedBy: apiv1alpha1.SecretProvider,
@@ -95,7 +93,6 @@ func CreateDb2ToS3CopyModule() *apiv1alpha1.M4DModule {
 			Namespace: "default",
 		},
 		Spec: apiv1alpha1.M4DModuleSpec{
-			Type:  apiv1alpha1.Service,
 			Flows: []apiv1alpha1.ModuleFlow{apiv1alpha1.Copy},
 			Capabilities: apiv1alpha1.Capability{
 				CredentialsManagedBy: apiv1alpha1.SecretProvider,

--- a/manager/testdata/e2e/module-implicit-copy-db2wh-to-s3.yaml
+++ b/manager/testdata/e2e/module-implicit-copy-db2wh-to-s3.yaml
@@ -49,13 +49,12 @@ metadata:
   namespace: m4d-system  # In future, will be a parameter defined by admin
   labels:
     name: implicit-copy-db2wh-to-s3 # module name
-    version: 1.0.0
+    version: 0.1.0
   annotations:
     author: "Example Author (author@example.com)"
     summary: "a short description of this module"
     description: "a longer description of this module that might e.g. be used in contracts"
 spec:
-  type: service # one of: job, service, configuration
   flows:  # one or more of copy, read, write
   - copy
   capabilities:

--- a/manager/testdata/e2e/module-implicit-copy-kafka-to-s3-stream.yaml
+++ b/manager/testdata/e2e/module-implicit-copy-kafka-to-s3-stream.yaml
@@ -49,13 +49,12 @@ metadata:
   namespace: m4d-system  # In future, will be a parameter defined by admin
   labels:
     name: implicit-copy-kafka-to-s3-stream # module name
-    version: 1.0.0 
+    version: 0.1.0 
   annotations:
     author: "Example Author (author@example.com)"
     summary: "a short description of this module"
     description: "a longer description of this module that might e.g. be used in contracts"
 spec:
-  type: service # one of: job, service, configuration
   flows:  # one or more of copy, read, write 
   - copy  
   capabilities:

--- a/manager/testdata/e2e/module-implicit-copy-s3-to-s3.yaml
+++ b/manager/testdata/e2e/module-implicit-copy-s3-to-s3.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: app.m4d.ibm.com/v1alpha1
+kind: M4DModule
+metadata:
+  name: implicit-copy-s3-to-s3-batch # module name
+  namespace: m4d-system  # In future, will be a parameter defined by admin
+  labels:
+    name: implicit-copy-s3-to-s3-batch # module name
+    version: 0.1.0 
+  annotations:
+    author: "Example Author (author@example.com)"
+    summary: "a short description of this module"
+    description: "a longer description of this module that might e.g. be used in contracts"
+spec:
+  flows:  # one or more of copy, read, write 
+  - copy  
+  capabilities:
+    credentials-managed-by: secret-provider #secret-provider or data-mesh-auto i.e. module calls secret-provider, or credentils injected by data-mesh
+    supportedInterfaces:
+    - flow: copy      
+      source: 
+        protocol: s3
+        dataformat: csv
+      sink: 
+        protocol: s3
+        dataformat: parquet
+    actions:
+    - id: redact-ID
+      level: 2  # column
+    - id: removed-ID
+      level: 2  # column
+  chart: ghcr.io/the-mesh-for-data/m4d-s3-to-s3:0.1.0
+  statusIndicators:
+    - kind: BatchTransfer
+      successCondition: status.status == SUCCEEDED
+      failureCondition: status.status == FAILED
+      errorMessage: status.error


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@il.ibm.com>

Fixes https://github.com/IBM/the-mesh-for-data/issues/108

This PR revisits m4dmodule structure and corresponding yamls. 
- Removes Type from the module spec
- Adjusts version to match the chart version
- Adds a module for s3-s3 implicit copy