### PR TITLE
os: automate setup of a ubuntu host from scrach

### DIFF
--- a/.mk/verify.mk
+++ b/.mk/verify.mk
@@ -18,13 +18,6 @@ define license_python
 	($(ABSTOOLBIN)/license_finder --python-version=3 || true)
 endef
 
-GO_VERSION:=1.13
-CODE_MAINT += go-version
-.PHONY: go-version
-go-version:
-	@(go version | grep -q 'go$(GO_VERSION)\(\.[0-9]*\)\? ') || \
-	echo 'WARNING: bad go version to fix run: eval "$$(gimme $(GO_VERSION))"'
-
 CODE_MAINT += fmt
 .PHONY: fmt
 fmt:

--- a/hack/tools/install_os.sh
+++ b/hack/tools/install_os.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+set -e
+
+ID=$(lsb_release -i)
+ID=${ID##Distributor ID:[[:space:]]}
+RELEASE=$(lsb_release -r)
+RELEASE=${RELEASE##Release:[[:space:]]}
+
+install_ubuntu() {
+	sudo apt update
+	sudo apt install -y python3
+	sudo apt install -y python3-pip
+	sudo apt install -y python3-setuptools
+	sudo apt install -y asciidoctor
+	sudo apt install -y conntrack
+	sudo apt install -y ethtool
+	sudo apt install -y apache2-utils
+	sudo apt install -y maven
+	sudo apt install -y docker.io
+}
+
+case $ID in
+	Ubuntu)
+		install_ubuntu
+		;;
+	*)
+		echo "$id not supported!"
+		exit 1
+esac


### PR DESCRIPTION
provide a means for setting up an ubuntu host from scrach (works on VM and on WSL), addressing part of https://github.com/IBM/the-mesh-for-data/issues/127