### PR TITLE
Support multiple data stores

### DIFF
--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -56,12 +56,6 @@ type WriteModuleArgs struct {
 // In the future might support output args as well
 // The arguments passed depend on the type of module
 type ModuleArguments struct {
-
-	// ONE AND ONLY ONE OF THE FOLLOWING FIELDS SHOULD BE POPULATED
-	// Flow is the selector for this union
-	// +required
-	Flow ModuleFlow `json:"flow"`
-
 	// CopyArgs are parameters specific to modules that copy data from one data store to another.
 	// +optional
 	Copy *CopyModuleArgs `json:"copy,omitempty"`

--- a/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_blueprints.yaml
@@ -208,13 +208,6 @@ spec:
                             - destination
                             - source
                             type: object
-                          flow:
-                            description: ONE AND ONLY ONE OF THE FOLLOWING FIELDS SHOULD BE POPULATED Flow is the selector for this union
-                            enum:
-                            - copy
-                            - read
-                            - write
-                            type: string
                           read:
                             description: ReadArgs are parameters that are specific to modules that enable an application to read data
                             items:
@@ -409,8 +402,6 @@ spec:
                               - destination
                               type: object
                             type: array
-                        required:
-                        - flow
                         type: object
                       name:
                         description: Name is the name of the instance of the module. For example, if the application is named "notebook" and an implicitcopy module is deemed necessary.  The FlowStep name would be notebook-implicitcopy.

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -217,7 +217,7 @@ func (r *BlueprintReconciler) reconcile(ctx context.Context, log logr.Logger, bl
 
 		// TODO: current Copy modules do not expect the "copy" key.
 		//       once updated, these lines could be dropped
-		if step.Arguments.Flow == app.Copy {
+		if step.Arguments.Copy != nil {
 			args = args["copy"].(map[string]interface{})
 		}
 

--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -221,7 +221,9 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 			return ctrl.Result{}, err
 		}
 	}
-	blueprintSpec := r.GenerateBlueprint(instances, applicationContext)
+	// unite several instances of a read/write module
+	newInstances := r.RefineInstances(instances)
+	blueprintSpec := r.GenerateBlueprint(newInstances, applicationContext)
 	r.Log.V(0).Info("Blueprint entrypoint: " + blueprintSpec.Entrypoint)
 
 	blueprint := r.GetBlueprintSignature(applicationContext)

--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -350,7 +350,7 @@ var _ = Describe("M4DApplication Controller", func() {
 		// Enforcement actions for the first dataset: redact on read, encrypt on copy
 		// Enforcement action for the second dataset: Allow
 		// Applied copy module kafka->s3 and db2->s3 supporting redact and encrypt actions
-		// Result: blueprint is created successfully
+		// Result: blueprint is created successfully, a read module is applied once for both datasets
 
 		It("Test blueprint-created", func() {
 			// allocate storage
@@ -400,13 +400,24 @@ var _ = Describe("M4DApplication Controller", func() {
 			}, timeout, interval).ShouldNot(BeEmpty())
 
 			By("Expecting blueprint to be generated")
+			blueprint := &apiv1alpha1.Blueprint{}
 			Eventually(func() error {
 				Expect(k8sClient.Get(context.Background(), appSignature, resource)).Should(Succeed())
-				f := &apiv1alpha1.Blueprint{}
 				key := appSignature
 				key.Namespace = resource.Status.BlueprintNamespace
-				return k8sClient.Get(context.Background(), key, f)
+				return k8sClient.Get(context.Background(), key, blueprint)
 			}, timeout, interval).Should(Succeed())
+
+			// Check the generated blueprint
+			// There should be a single read module with two datasets
+			numReads := 0
+			for _, step := range blueprint.Spec.Flow.Steps {
+				if step.Template == readPathModule.Name {
+					numReads++
+					Expect(len(step.Arguments.Read)).To(Equal(2))
+				}
+			}
+			Expect(numReads).To(Equal(1))
 		})
 	})
 })

--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -166,7 +166,6 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 		}
 		// append moduleinstances to the list
 		copyArgs := &app.ModuleArguments{
-			Flow: app.Copy,
 			Copy: &app.CopyModuleArgs{
 				Source:          *sourceDataStore,
 				Destination:     *sinkDataStore,
@@ -189,7 +188,6 @@ func (r *M4DApplicationReconciler) SelectModuleInstancesPerDataset(item modules.
 		AssetID:         item.AssetID,
 		Transformations: actionsOnRead.EnforcementActions})
 	readArgs := &app.ModuleArguments{
-		Flow: app.Read,
 		Read: readInstructions,
 	}
 	instances = append(instances, readSelector.AddModuleInstances(readArgs, item)...)


### PR DESCRIPTION
This PR fixes https://github.com/IBM/the-mesh-for-data/issues/103
Goal: to avoid multiple instances of any given read/write module 

Introduced changes:
- ModuleArguments structure does not contain Flow. Arguments may contain any number of Read and Write elements.
- Prior to blueprint generation, module instances are revisited. If there are several instances of the same read/write module, they are combined into a single instance.
- Added a test that checks that a single read module is constructed in a blueprint in the case of multiple data assets.