### PR TITLE
manager: Change manager image in correct folder

### DIFF
--- a/manager/Makefile
+++ b/manager/Makefile
@@ -38,7 +38,7 @@ undeploy_mc: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl
 
 deploy_it: docker-secret
 	$(TOOLBIN)/kubectl create namespace ${KUBE_NAMESPACE} || true
-	cd config/integration-tests && $(ABSTOOLBIN)/kustomize edit set image controller=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/manager:${DOCKER_TAGNAME}
+	cd config/manager && $(ABSTOOLBIN)/kustomize edit set image controller=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/manager:${DOCKER_TAGNAME}
 	cd config/integration-tests && $(ABSTOOLBIN)/kustomize edit set image data-catalog-mock=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/data-catalog-mock:${DOCKER_TAGNAME}
 	cd config/integration-tests && $(ABSTOOLBIN)/kustomize edit set image policycompiler=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/serverpolicycompiler-mock:${DOCKER_TAGNAME}
 	$(TOOLBIN)/kustomize build --load_restrictor none config/integration-tests | $(TOOLBIN)/kubectl apply -f -

--- a/manager/config/integration-tests/kustomization.yaml
+++ b/manager/config/integration-tests/kustomization.yaml
@@ -16,9 +16,6 @@ patchesStrategicMerge:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: kind-registry:5000/m4d-system/manager
-  newTag: latest
 - name: data-catalog-mock
   newName: kind-registry:5000/m4d-system/data-catalog-mock
   newTag: latest


### PR DESCRIPTION
This is a fix for the integration tests that fixes the image of the deployed manager. It should use the kind-registry image for the integration tests.