### PR TITLE
policy-compiler: add data_location field in egeria input asset json 

### DIFF
--- a/connectors/egeria/src/main/java/com/ibm/egeria/EgeriaClient.java
+++ b/connectors/egeria/src/main/java/com/ibm/egeria/EgeriaClient.java
@@ -411,6 +411,10 @@ public final class EgeriaClient {
 
         //it can contain a direct link to the file or a json with remote object
         String qualifiedName = assetMetaDataHelper.getQualifiedName();
+        // fix for https://github.com/IBM/the-mesh-for-data/issues/122 - start 
+        JsonObject storeJson = JsonParser.parseString(qualifiedName).getAsJsonObject();
+        String geo = storeJson.get("data_location").getAsString();
+        // fix for https://github.com/IBM/the-mesh-for-data/issues/122 - end 
         DataStore dataStore = getAssetStore(qualifiedName);
 
         datasetDetails = DatasetDetails.newBuilder()
@@ -418,7 +422,8 @@ public final class EgeriaClient {
                         .setDataOwner(dataowner)
                         .setMetadata(metadata)
                         .setDataStore(dataStore)
-                        .setGeo("geo not supported yet") //should be in additionalProperties
+                        //.setGeo("geo not supported yet") //should be in additionalProperties
+                        .setGeo(geo)
                         .setDataFormat(typeOfAsset)
                         .build();
 

--- a/samples/kubeflow/example_transactions.csv.json
+++ b/samples/kubeflow/example_transactions.csv.json
@@ -2,7 +2,7 @@
     "class": "NewCSVFileAssetRequestBody",
     "displayName": "transactions.csv",
     "description": "Synthetic Financial Dataset For Fraud Detection",
-    "fullPath": "{\"data_store\":\"S3\", \"bucket\":\"m4d-bucket-example\", \"endpoint\":\"s3.eu-de.cloud-object-storage.appdomain.cloud\", \"object_key\":\"data.csv\", \"region\":\"eu\"}",
+    "fullPath": "{\"data_store\":\"S3\", \"bucket\":\"m4d-bucket-example\", \"endpoint\":\"s3.eu-de.cloud-object-storage.appdomain.cloud\", \"object_key\":\"data.csv\", \"region\":\"eu\", \"data_location\": \"US\"}",
     "columnHeaders": [
         "step", "type", "amount", "nameOrig", "oldbalanceOrg", "newbalanceOrig", "nameDest", "oldbalanceDest", "newbalanceDest","isFraud","isFlaggedFraud"
     ]

--- a/third_party/egeria/usage/example_transactions.csv.json
+++ b/third_party/egeria/usage/example_transactions.csv.json
@@ -2,7 +2,7 @@
     "class": "NewCSVFileAssetRequestBody",
     "displayName": "transactions.csv",
     "description": "Synthetic Financial Dataset For Fraud Detection",
-    "fullPath": "{\"data_store\":\"S3\", \"bucket\":\"mybucket\", \"endpoint\":\"s3.eu-de.cloud-object-storage.appdomain.cloud\", \"object_key\":\"transactions.csv\", \"region\":\"eu\"}",
+    "fullPath": "{\"data_store\":\"S3\", \"bucket\":\"mybucket\", \"endpoint\":\"s3.eu-de.cloud-object-storage.appdomain.cloud\", \"object_key\":\"transactions.csv\", \"region\":\"eu\", \"data_location\": \"France\"}",
     "columnHeaders": [
         "step", "type", "amount", "nameOrig", "oldbalanceOrg", "newbalanceOrig", "nameDest", "oldbalanceDest", "newbalanceDest","isFraud","isFlaggedFraud"
     ]

--- a/third_party/egeria/usage/example_transactions.csv.json
+++ b/third_party/egeria/usage/example_transactions.csv.json
@@ -2,7 +2,7 @@
     "class": "NewCSVFileAssetRequestBody",
     "displayName": "transactions.csv",
     "description": "Synthetic Financial Dataset For Fraud Detection",
-    "fullPath": "{\"data_store\":\"S3\", \"bucket\":\"mybucket\", \"endpoint\":\"s3.eu-de.cloud-object-storage.appdomain.cloud\", \"object_key\":\"transactions.csv\", \"region\":\"eu\", \"data_location\": \"France\"}",
+    "fullPath": "{\"data_store\":\"S3\", \"bucket\":\"mybucket\", \"endpoint\":\"s3.eu-de.cloud-object-storage.appdomain.cloud\", \"object_key\":\"transactions.csv\", \"region\":\"eu\", \"data_location\": \"US\"}",
     "columnHeaders": [
         "step", "type", "amount", "nameOrig", "oldbalanceOrg", "newbalanceOrig", "nameDest", "oldbalanceDest", "newbalanceDest","isFraud","isFlaggedFraud"
     ]


### PR DESCRIPTION
This PR fixes #122. We have added a "data_location" field (which is mandatory) in the asset json which is input to Egeria during configuration time. This field needs to be populated with the correct data_location of the asset and will be in turned parsed by egeria connector and set in the geo field of the data catalog response https://github.com/IBM/the-mesh-for-data/blob/89a5359b4f4c911eb366bfaa8612f25b919b0354/pkg/connectors/protos/data_catalog_response.proto#L54 which is sent to the manager. The manager further will process the geo field accordingly. 
