### PR TITLE
Multicluster: kind support

### DIFF
--- a/.mk/cluster.mk
+++ b/.mk/cluster.mk
@@ -14,6 +14,10 @@ minikube-cleanup: $(TOOLBIN)/minikube $(TOOLBIN)/kubectl
 kind-setup: $(TOOLBIN)/kind $(TOOLBIN)/kubectl
 	cd $(TOOLS_DIR); ./create_kind.sh
 
+.PHONY: kind-setup-multi
+kind-setup-multi: $(TOOLBIN)/kind $(TOOLBIN)/kubectl
+	cd $(TOOLS_DIR); ./create_kind.sh multi
+
 .PHONY: kind-cleanup
 kind-cleanup: $(TOOLBIN)/kind $(TOOLBIN)/kubectl
 	cd $(TOOLS_DIR); ./create_kind.sh cleanup

--- a/hack/tools/create_kind.sh
+++ b/hack/tools/create_kind.sh
@@ -59,37 +59,16 @@ certs_delete() {
 }
 
 kind_delete() {
-        bin/kind version
-        bin/kind delete cluster --name kind
-}
-
-kind_delete_control() {
-        bin/kind version
-        bin/kind delete cluster --name control
+        bin/kind delete cluster --name $1
 }
 
 kind_create() {
-        bin/kind version
-        bin/kind create cluster --name kind \
+        bin/kind create cluster --name $1 \
              -v 4 --retain --wait=0s \
-             --config ./kind-config.yaml \
+             --config ./$2 \
              --image=kindest/node:$K8S_VERSION
-        bin/kubectl config use-context kind-kind
-        for node in $(kind get nodes --name kind); do
-          bin/kubectl annotate node "${node}" "tilt.dev/registry=kind-registry:5000";
-          docker cp ../registry/ca.crt "$node":/usr/local/share/ca-certificates
-          docker exec "$node" update-ca-certificates
-        done
-}
-
-kind_create_control() {
-        bin/kind version
-        bin/kind create cluster --name control \
-             -v 4 --retain --wait=0s \
-             --config ./kind-control-config.yaml \
-             --image=kindest/node:$K8S_VERSION
-        bin/kubectl config use-context kind-control
-        for node in $(kind get nodes --name control); do
+        bin/kubectl config use-context kind-$1
+        for node in $(kind get nodes --name $1); do
           bin/kubectl annotate node "${node}" "tilt.dev/registry=kind-registry:5000";
           docker cp ../registry/ca.crt "$node":/usr/local/share/ca-certificates
           docker exec "$node" update-ca-certificates
@@ -101,16 +80,16 @@ case "$op" in
         header_text "Uninstalling kind cluster"
         registry_delete || true
         certs_delete || true
-        kind_delete || true
-        kind_delete_control || true
+        kind_delete kind || true
+        kind_delete control || true
         ;;
     multi)
         header_text "Installing kind multi-cluster"
         certs_create
         install_certs
-        kind_create
+        kind_create kind kind-config.yaml
         registry_create
-        kind_create_control
+        kind_create control kind-control-config.yaml
         ;;
     *)
         header_text "Installing kind cluster"

--- a/hack/tools/create_kind.sh
+++ b/hack/tools/create_kind.sh
@@ -95,7 +95,7 @@ case "$op" in
         header_text "Installing kind cluster"
         certs_create
         install_certs
-        kind_create
+        kind_create kind kind-config.yaml
         registry_create
         ;;
 esac

--- a/hack/tools/kind-control-config.yaml
+++ b/hack/tools/kind-control-config.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30333  # Razee dash API node port in K8s
+    hostPort: 3333  # Razee dash API on host
+  - containerPort: 30080  # Razee dash UI node port in K8s
+    hostPort: 8080  # Razee dash UI on host
+- role: worker
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["https://kind-registry:5000"]

--- a/website/content/contribute/code/flow/index.md
+++ b/website/content/contribute/code/flow/index.md
@@ -122,7 +122,7 @@ make e2e
 
 # Building in a multi cluster environment
 
-As {{< name >}} is can run in a multi-cluster environment there is also a test environment
+As {{< name >}} can run in a multi-cluster environment there is also a test environment
 that can be used that simulates this scenario. Using kind one can spin up two separate kubernetes
 clusters with differnt contexts and develop and test in these. 
 

--- a/website/content/contribute/code/flow/index.md
+++ b/website/content/contribute/code/flow/index.md
@@ -120,6 +120,17 @@ Running end to end tests:
 make e2e
 ```
 
+# Building in a multi cluster environment
+
+As the-mesh-for-data is can run in a multi-cluster environment there is also a test environment
+that can be used that simulates this scenario. Using kind one can spin up two separate kubernetes
+clusters with differnt contexts and develop and test in these. 
+
+Two kind clusters that share the same kind-registry can be set up using:
+```bash
+make kind-setup-multi
+``` 
+
 # Normalize the code
 
 To ensure the code is formatted uniformly we use various linters which are

--- a/website/content/contribute/code/flow/index.md
+++ b/website/content/contribute/code/flow/index.md
@@ -122,7 +122,7 @@ make e2e
 
 # Building in a multi cluster environment
 
-As the-mesh-for-data is can run in a multi-cluster environment there is also a test environment
+As {{< name >}} is can run in a multi-cluster environment there is also a test environment
 that can be used that simulates this scenario. Using kind one can spin up two separate kubernetes
 clusters with differnt contexts and develop and test in these. 
 


### PR DESCRIPTION
This PR Adds support to spin up two kind clusters in the same dev environment. 
These kind clusters share one registry so that images only have to be uploaded once.