### PR TITLE
changes to helm values

### DIFF
--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -215,13 +215,6 @@ func (r *BlueprintReconciler) reconcile(ctx context.Context, log logr.Logger, bl
 			return ctrl.Result{}, errors.WithMessage(err, "Blueprint step arguments are invalid")
 		}
 
-		// Add metadata arguments (namespace, name, labels, etc.)
-		hashedName := utils.Hash(step.Name, 20)
-		args["metadata"] = map[string]interface{}{
-			"name":      hashedName,
-			"namespace": blueprint.Namespace,
-			"labels":    blueprint.Labels,
-		}
 		releaseName := getReleaseName(step)
 		log.V(0).Info("Release name: " + releaseName)
 		numReleases++
@@ -236,8 +229,7 @@ func (r *BlueprintReconciler) reconcile(ctx context.Context, log logr.Logger, bl
 				}
 			}
 		} else if rel.Info.Status == release.StatusDeployed {
-			// TODO: add release notes of the read module to the status
-			if args["flow"] == "read" {
+			if len(step.Arguments.Read) > 0 {
 				blueprint.Status.DataAccessInstructions += rel.Info.Notes
 			}
 			status, errMsg := r.checkReleaseStatus(releaseName, blueprint.Namespace)

--- a/modules/m4d-db2wh/templates/batchtransfer.yaml
+++ b/modules/m4d-db2wh/templates/batchtransfer.yaml
@@ -4,7 +4,7 @@
 apiVersion: motion.m4d.ibm.com/v1alpha1
 kind: BatchTransfer
 metadata:
-  name: {{ .Release.name }}
+  name: {{ .Release.Name }}
 spec:
   source:
     database:

--- a/modules/m4d-db2wh/templates/batchtransfer.yaml
+++ b/modules/m4d-db2wh/templates/batchtransfer.yaml
@@ -4,12 +4,7 @@
 apiVersion: motion.m4d.ibm.com/v1alpha1
 kind: BatchTransfer
 metadata:
-  name: {{ .Values.metadata.name }}
-  namespace: {{ .Values.metadata.namespace }}
-  labels:
-  {{ range $key, $value := .Values.metadata.labels }}
-    {{ $key }}: {{ $value }}
-  {{ end }}        
+  name: {{ .Release.name }}
 spec:
   source:
     database:

--- a/modules/m4d-db2wh/values.yaml
+++ b/modules/m4d-db2wh/values.yaml
@@ -5,12 +5,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# metadata associated with k8s resources
-metadata:
-  name: "db2wh"
-  namespace: "default"
-  labels: []
-
 image: "ghcr.io/the-mesh-for-data/mover:latest"
 imagePullPolicy: null
 noFinalizer: "false"

--- a/modules/m4d-db2wh/values.yaml.sample
+++ b/modules/m4d-db2wh/values.yaml.sample
@@ -1,8 +1,3 @@
-metadata:
-  labels: {}
-  name: 012d42539692bba841a7
-  namespace: default
-
 image: kind-registry:5000/m4d-system/dummy-mover:latest
 imagePullSecret: IfNotPresent
 

--- a/modules/m4d-kafka/templates/streamtransfer.yaml
+++ b/modules/m4d-kafka/templates/streamtransfer.yaml
@@ -4,7 +4,7 @@
 apiVersion: motion.m4d.ibm.com/v1alpha1
 kind: StreamTransfer
 metadata:
-  name: {{ .Release.name }}
+  name: {{ .Release.Name }}
 spec:
   source:
     kafka:

--- a/modules/m4d-kafka/templates/streamtransfer.yaml
+++ b/modules/m4d-kafka/templates/streamtransfer.yaml
@@ -4,12 +4,7 @@
 apiVersion: motion.m4d.ibm.com/v1alpha1
 kind: StreamTransfer
 metadata:
-  name: {{ .Values.metadata.name }}
-  namespace: {{ .Values.metadata.namespace }}
-  labels:
-  {{ range $key, $value := .Values.metadata.labels }}
-    {{ $key }}: {{ $value }}
-  {{ end }}        
+  name: {{ .Release.name }}
 spec:
   source:
     kafka:

--- a/modules/m4d-kafka/values.yaml
+++ b/modules/m4d-kafka/values.yaml
@@ -5,12 +5,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# metadata associated with k8s resources
-metadata:
-  name: "kafka"
-  namespace: "default"
-  labels: []
-
 image: "ghcr.io/the-mesh-for-data/mover:latest"
 imagePullPolicy: null
 noFinalizer: "false"

--- a/modules/m4d-kafka/values.yaml.sample
+++ b/modules/m4d-kafka/values.yaml.sample
@@ -1,8 +1,3 @@
-metadata:
-  labels: {}
-  name: 012d42539692bba841a7
-  namespace: default
-
 image: kind-registry:5000/m4d-system/dummy-mover:latest
 
 copy:

--- a/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
+++ b/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
@@ -4,7 +4,7 @@
 apiVersion: motion.m4d.ibm.com/v1alpha1
 kind: BatchTransfer
 metadata:
-  name: {{ .Release.name }}
+  name: {{ .Release.Name }}
 spec:
   source:
     s3:

--- a/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
+++ b/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
@@ -4,12 +4,7 @@
 apiVersion: motion.m4d.ibm.com/v1alpha1
 kind: BatchTransfer
 metadata:
-  name: {{ .Values.metadata.name }}
-  namespace: {{ .Values.metadata.namespace }}
-  labels:
-  {{ range $key, $value := .Values.metadata.labels }}
-    {{ $key }}: {{ $value }}
-  {{ end }}        
+  name: {{ .Release.name }}
 spec:
   source:
     s3:


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@il.ibm.com>
Refers to https://github.com/IBM/the-mesh-for-data/issues/143

Values passed to a module chart should not contain metadata(name and namespace) as they are specified in Release.
Currently ignoring labels.