### PR TITLE
Use python slim image for secret provider

### DIFF
--- a/secret-provider/Dockerfile
+++ b/secret-provider/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.6
+FROM python:3.6-slim
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Signed-off-by: Florian Froese <ffr@zurich.ibm.com>

Hi @tomersolomon1! Can we use the slim python image? This would speed up builds quite a bit as the python image is currently more than 500MB ...