### PR TITLE
multicluster: Add a dummy multi cluster manager

### DIFF
--- a/pkg/multicluster/dummy/dummy_manager.go
+++ b/pkg/multicluster/dummy/dummy_manager.go
@@ -1,0 +1,44 @@
+package dummy
+
+import (
+	"errors"
+	"github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
+	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
+)
+
+// This ClusterManager is meant to be used for testing
+type MultiClusterManager struct {
+	DeployedBlueprints map[string]*v1alpha1.Blueprint
+}
+
+func (m *MultiClusterManager) GetClusters() ([]multicluster.Cluster, error) {
+	return []multicluster.Cluster{
+		{
+			Name:     "kind-kind",
+			Metadata: multicluster.ClusterMetadata{},
+		},
+	}, nil
+}
+
+func (m *MultiClusterManager) GetBlueprint(cluster string, namespace string, name string) (*v1alpha1.Blueprint, error) {
+	blueprint, found := m.DeployedBlueprints[cluster]
+	if found {
+		return blueprint, nil
+	}
+	return nil, errors.New("Blueprint not found")
+}
+
+func (m *MultiClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+	m.DeployedBlueprints[cluster] = blueprint
+	return nil
+}
+
+func (m *MultiClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+	m.DeployedBlueprints[cluster] = blueprint
+	return nil
+}
+
+func (m *MultiClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
+	delete(m.DeployedBlueprints, cluster)
+	return nil
+}

--- a/pkg/multicluster/dummy/dummy_manager_test.go
+++ b/pkg/multicluster/dummy/dummy_manager_test.go
@@ -1,0 +1,68 @@
+package dummy
+
+import (
+	"errors"
+	app "github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
+	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestDummyMultiClusterManager(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	blueprint := &app.Blueprint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "n",
+			Namespace: "ns",
+		},
+	}
+	manager := MultiClusterManager{
+		DeployedBlueprints: make(map[string]*app.Blueprint),
+	}
+
+	// Test listing clusters
+	clusters, err := manager.GetClusters()
+	g.Expect(clusters).To(gomega.Equal([]multicluster.Cluster{{Name: "kind-kind", Metadata: multicluster.ClusterMetadata{}}}))
+	g.Expect(err).To(gomega.BeNil())
+
+	// Test creating a blueprint
+	err = manager.CreateBlueprint("kind-kind", blueprint)
+	g.Expect(err).To(gomega.BeNil())
+
+	// Test retrieving the before created blueprint
+	getBlueprint, err := manager.GetBlueprint("kind-kind", "ns", "n")
+	g.Expect(getBlueprint).To(gomega.Equal(blueprint))
+	g.Expect(err).To(gomega.BeNil())
+
+	blueprint2 := &app.Blueprint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "n2",
+			Namespace: "ns2",
+		},
+	}
+
+	// Test updating blueprint
+	err = manager.UpdateBlueprint("kind-kind", blueprint2)
+	g.Expect(err).To(gomega.BeNil())
+
+	// Test retrieving the before updated blueprint
+	getBlueprint, err = manager.GetBlueprint("kind-kind", "ns", "n")
+	g.Expect(getBlueprint).To(gomega.Equal(blueprint2))
+	g.Expect(getBlueprint.Name).To(gomega.Equal("n2"))
+	g.Expect(err).To(gomega.BeNil())
+
+	// Test removing the blueprint
+	err = manager.DeleteBlueprint("kind-kind", "ns", "n")
+	g.Expect(err).To(gomega.BeNil())
+
+	// Test removing a non-existing blueprint (just a no-op)
+	err = manager.DeleteBlueprint("kind-kind", "ns", "n")
+	g.Expect(err).To(gomega.BeNil())
+
+	// Test retrieving a non-existing blueprint
+	getBlueprint, err = manager.GetBlueprint("kind-kind", "ns", "n")
+	g.Expect(getBlueprint).To(gomega.BeNil())
+	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+	g.Expect(err).To(gomega.Equal(errors.New("Blueprint not found")))
+}


### PR DESCRIPTION
Signed-off-by: Florian Froese <ffr@zurich.ibm.com>

This PR is part of a larger effort to get #136 merged. 
This part is adding a ClusterManager that can be used for development and testing when no real connection to an external system is required.