### PR TITLE
Remove line that logs token

### DIFF
--- a/manager/main.go
+++ b/manager/main.go
@@ -157,7 +157,6 @@ func main() {
 // init vault client and mount the base directory for storing credentials
 func initVaultConnection() (*api.Client, error) {
 	token := utils.GetVaultToken()
-	setupLog.Info("Token is " + token)
 	if err := utils.MountDatasetVault(token); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Florian Froese <ffr@zurich.ibm.com>

Logging credentials is a potential security risk and should never have been added.