### PR TITLE
Multicluster: local razee secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ docker-build-local:
 helm:
 	$(MAKE) -C modules helm
 
+.PHONY: helm-chart-push
+helm-chart-push:
+	$(MAKE) -C modules helm-chart-push
+
 DOCKER_PUBLIC_HOSTNAME ?= ghcr.io
 DOCKER_PUBLIC_NAMESPACE ?= the-mesh-for-data
 DOCKER_PUBLIC_NAMES := \
@@ -114,4 +118,3 @@ endif
 include hack/make-rules/tools.mk
 include hack/make-rules/verify.mk
 include hack/make-rules/cluster.mk
-include hack/make-rules/helm.mk

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,6 @@ docker-build-local:
 helm:
 	$(MAKE) -C modules helm
 
-.PHONY: helm-chart-push
-helm-chart-push:
-	$(MAKE) -C modules helm-chart-push
-
 DOCKER_PUBLIC_HOSTNAME ?= ghcr.io
 DOCKER_PUBLIC_NAMESPACE ?= the-mesh-for-data
 DOCKER_PUBLIC_NAMES := \

--- a/hack/setup-local-multi-cluster.sh
+++ b/hack/setup-local-multi-cluster.sh
@@ -1,0 +1,29 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+# This script is meant for local development with kind
+
+export DOCKER_HOSTNAME=kind-registry:5000
+export DOCKER_NAMESPACE=m4d-system
+export HELM_EXPERIMENTAL_OCI=1
+
+make kind-setup-multi
+kubectl config use-context kind-control
+make -C third_party/razee all
+
+kubectl config use-context kind-control
+make docker-minimal-it
+make cluster-prepare
+make cluster-prepare-wait
+make -C secret-provider configure-vault
+make -C secret-provider deploy
+make -C manager deploy_it
+make -C manager wait_for_manager
+make -C modules helm-chart-push
+
+kubectl config use-context kind-kind
+make cluster-prepare
+make cluster-prepare-wait
+make -C secret-provider configure-vault
+make -C secret-provider deploy
+make -C manager deploy_it
+make -C manager wait_for_manager

--- a/third_party/razee/razeedeploy-delta-install-template.yaml
+++ b/third_party/razee/razeedeploy-delta-install-template.yaml
@@ -70,11 +70,11 @@ spec:
       - name: razeedeploy-job
         image: "quay.io/razee/razeedeploy-delta:2.1.0"
         command: ["node", "src/install", "--namespace=razeedeploy"]
-        args: ["--razeedash-url=$RAZEEDASH_URL",
+        args: ["--razeedash-api=$RAZEEDASH_API",
                "--razeedash-org-key=$ORGAPIKEY",
                "--razeedash-cluster-id=$CLUSTERID",
                "--razeedash-cluster-metadata64=$CLUSTERNAMEB64",
-               "--rr", "--rrs3", "--wk", "--mtp", "--ffsld", "--ms", "-a"]
+               "--cs", "--rr", "--rrs3", "--wk", "--mtp", "--ffsld", "--ms"]
         # see README.md for args options. https://github.com/razee-io/razeedeploy-delta/blob/master/README.md
       restartPolicy: Never
   backoffLimit: 2

--- a/third_party/razee/setupCluster.sh
+++ b/third_party/razee/setupCluster.sh
@@ -28,9 +28,9 @@ fi
 CLUSTERNAME=$1
 
 if [ -z "$2" ]; then
-  export RAZEEDASH_URL="http://control-control-plane:30333/api/v2"
+  export RAZEEDASH_API="http://control-control-plane:30333"
 else
-  export RAZEEDASH_URL=$2
+  export RAZEEDASH_API=$2
 fi
 
 kubectl config use-context $CLUSTERNAME
@@ -53,6 +53,9 @@ CURLRESULT=$(curl --request POST \
 
 export ORGAPIKEY=$(echo $CURLRESULT | jq .data.registerCluster.orgKey -r)
 export CLUSTERID=$(echo $CURLRESULT | jq .data.registerCluster.clusterId -r)
+
+kubectl create ns m4d-system || true
+kubectl -n m4d-system create secret generic razee-credentials --from-literal=RAZEE_ORG_ID=$ORGID --from-literal=RAZEE_URL="$RAZEEDASH_API/graphql" --from-literal=RAZEE_USER="$RAZEE_USER" --from-literal=RAZEE_PASSWORD=$RAZEE_PASSWORD
 
 if [ $ORGAPIKEY == "null" ]; then
   echo "Could not register cluster!"


### PR DESCRIPTION
This PR improves the local development environment that is used for multi cluster development.
It creates a secret with razee credentials that can be mounted to a pod in order to connect with razee.
Currently the automated setup supports razee local as authentication for local development.