### PR TITLE
Change behaviour of default opa policy

### DIFF
--- a/connectors/opa/lib/opa_reader.go
+++ b/connectors/opa/lib/opa_reader.go
@@ -186,9 +186,9 @@ func buildNewEnfrocementAction(transformAction interface{}) (*pb.EnforcementActi
 						Level: pb.EnforcementAction_COLUMN, Args: map[string]string{"column_name": columnName}}
 					return newEnforcementAction, newUsedPolicy, true
 				}
-			case "reduct column":
+			case "redact column":
 				if columnName, ok := extractArgument(action["arguments"], "column_name"); ok {
-					newEnforcementAction := &pb.EnforcementAction{Name: "reducted", Id: "reducted-ID",
+					newEnforcementAction := &pb.EnforcementAction{Name: "redacted", Id: "redacted-ID",
 						Level: pb.EnforcementAction_COLUMN, Args: map[string]string{"column_name": columnName}}
 					return newEnforcementAction, newUsedPolicy, true
 				}

--- a/third_party/opa/data-and-policies/data_policies/action_struct.rego
+++ b/third_party/opa/data-and-policies/data_policies/action_struct.rego
@@ -80,9 +80,9 @@ build_encrypt_column_action(column_name, used_policies) = action {
     action = build_action(encrypt_column_struct.action_name, encrypt_column_struct.description, args, used_policies)
 }
 
-#mask_reduct_column
-reduct_column_struct = {
-    "action_name" : "reduct column",
+#mask_redact_column
+redact_column_struct = {
+    "action_name" : "redact column",
     "description" : "Single column is obfuscated with XXX instead of values",
     "arguments" : { 
         "column_name": "<column name>"
@@ -90,11 +90,11 @@ reduct_column_struct = {
     "used_policy" : "<used_policy_struct>"
 }
 
-build_reduct_column_action(column_name, used_policies) = action {
+build_redact_column_action(column_name, used_policies) = action {
     args := { 
        "column_name" : column_name
     }
-    action = build_action(reduct_column_struct.action_name, reduct_column_struct.description, args, used_policies)
+    action = build_action(redact_column_struct.action_name, redact_column_struct.description, args, used_policies)
 }
 
 #periodic_blackout

--- a/third_party/opa/data-and-policies/user_policies.rego
+++ b/third_party/opa/data-and-policies/user_policies.rego
@@ -42,12 +42,14 @@ transform[action] {
     not dp.check_destination([dp.GeoDestinations.US])
     
     column_names := dp.column_with_any_tag(["SPI", "SMI"])
-    action = dp.build_encrypt_column_action(column_names[_], dp.build_policy_from_description(description))
+    #action = dp.build_encrypt_column_action(column_names[_], dp.build_policy_from_description(description))
+    action = dp.build_redact_column_action(column_names[_], dp.build_policy_from_description(description))
 }
 
 #for transactions dataset
 transform[action] {
-	description = "test for transactions dataset that encrypts some columns by name"
+	#description = "test for transactions dataset that encrypts some columns by name"
+    description = "test for transactions dataset that redacts some columns by name"
     
 	dp.correct_input
     
@@ -57,7 +59,9 @@ transform[action] {
     dp.dataset_has_tag("Finance")
     
     column_names := dp.column_with_any_name({"nameOrig", "nameDest"})
-    action = dp.build_encrypt_column_action(column_names[_], dp.build_policy_from_description(description))
+    #action = dp.build_encrypt_column_action(column_names[_], dp.build_policy_from_description(description))
+    action = dp.build_redact_column_action(column_names[_], dp.build_policy_from_description(description))    
+    
 }
 
 #for transactions dataset


### PR DESCRIPTION
This PR fixes #190 . 
The cause of this error was that the default behaviour of the example opa policy is set to return Encrypt enforcement action instead of Redact enforcement action. This is now being changed in this PR. Also there were some spelling errors for redact. This is also corrected. 