### PR TITLE
renaming asset id in read args

### DIFF
--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -176,7 +176,7 @@ func (m *ModuleManager) SelectModuleInstances(item modules.DataInfo) ([]modules.
 	readInstructions := make([]app.ReadModuleArgs, 0)
 	readInstructions = append(readInstructions, app.ReadModuleArgs{
 		Source:          readSource,
-		AssetID:         item.AssetID,
+		AssetID:         utils.CreateDataSetIdentifier(item.AssetID),
 		Transformations: readSelector.Actions})
 	readArgs := &app.ModuleArguments{
 		Read: readInstructions,

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -113,7 +113,7 @@ func CreateDataSetIdentifier(datasetID string) string {
 
 	id := ""
 	for _, key := range keys {
-		id += key + "/" + jsonMap[key] + "/"
+		id += key + "-" + jsonMap[key] + "-"
 	}
 	return id[:len(id)-1]
 }


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@il.ibm.com>

Changing assetID to avoid JSON inside read arguments. 
A string of the form {key1:value1, key2:value2} will be replaced by key1-value1-key2-value2