### PR TITLE
Remove created Razee components if a creation of a channel version or…

### DIFF
--- a/pkg/multicluster/razee/razee_cluster_manager.go
+++ b/pkg/multicluster/razee/razee_cluster_manager.go
@@ -208,22 +208,22 @@ func (r *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blu
 	_, err = r.con.Subscriptions.AddSubscription(r.orgId, channelName, channel.UUID, channelVersion.VersionUUID, []string{groupName})
 	if err != nil {
 		// Remove channelVersion and channel if the subscription could not be created
-		removeChannel, versionRemoveErr := r.con.Versions.RemoveChannelVersion(r.orgId, channelVersion.VersionUUID)
+		removeChannelVersion, versionRemoveErr := r.con.Versions.RemoveChannelVersion(r.orgId, channelVersion.VersionUUID)
 		if versionRemoveErr != nil {
 			r.log.Error(versionRemoveErr, "Unable to remove channel version after error")
-		} else if removeChannel.Success {
+		} else if removeChannelVersion.Success {
 			r.log.Info("Rolled back channel version after error")
 		}
-		removeChannelVersion, channelRemoveErr := r.con.Channels.RemoveChannel(r.orgId, channel.UUID)
+		removeChannel, channelRemoveErr := r.con.Channels.RemoveChannel(r.orgId, channel.UUID)
 		if channelRemoveErr != nil {
 			r.log.Error(channelRemoveErr, "Unable to remove channel after error")
-		} else if removeChannelVersion.Success {
+		} else if removeChannel.Success {
 			r.log.Info("Rolled back channel after error")
 		}
 		return err
 	}
 
-	r.log.Info("Successfully created subscription! ")
+	r.log.Info("Successfully created subscription!")
 	return nil
 }
 

--- a/pkg/multicluster/razee/razee_cluster_manager.go
+++ b/pkg/multicluster/razee/razee_cluster_manager.go
@@ -193,12 +193,33 @@ func (r *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blu
 	// create channel version
 	channelVersion, err := r.con.Versions.AddChannelVersion(r.orgId, channel.UUID, version, content, "")
 	if err != nil {
+		// Remove channel if channelVersion could not be created
+		removeChannel, channelRemoveErr := r.con.Channels.RemoveChannel(r.orgId, channel.UUID)
+		if channelRemoveErr != nil {
+			r.log.Error(channelRemoveErr, "Unable to remove channel after error")
+		} else if removeChannel.Success {
+			r.log.Info("Rolled back channel version after error")
+		}
+
 		return err
 	}
 
 	// create subscription
 	_, err = r.con.Subscriptions.AddSubscription(r.orgId, channelName, channel.UUID, channelVersion.VersionUUID, []string{groupName})
 	if err != nil {
+		// Remove channelVersion and channel if the subscription could not be created
+		removeChannel, versionRemoveErr := r.con.Versions.RemoveChannelVersion(r.orgId, channelVersion.VersionUUID)
+		if versionRemoveErr != nil {
+			r.log.Error(versionRemoveErr, "Unable to remove channel version after error")
+		} else if removeChannel.Success {
+			r.log.Info("Rolled back channel version after error")
+		}
+		removeChannelVersion, channelRemoveErr := r.con.Channels.RemoveChannel(r.orgId, channel.UUID)
+		if channelRemoveErr != nil {
+			r.log.Error(channelRemoveErr, "Unable to remove channel after error")
+		} else if removeChannelVersion.Success {
+			r.log.Info("Rolled back channel after error")
+		}
 		return err
 	}
 


### PR DESCRIPTION
… subscription fails

Signed-off-by: Florian Froese <ffr@zurich.ibm.com>

This is a security mechanism to not create hundreds of channels when the channel version creation or subscription creation fails. Like this the already created components are removed again. (Similar to a roll-back in a DB transaction but with no guarantees as the deletions may fail)