### PR TITLE
Fix opa tests to not show popup for OS X

### DIFF
--- a/connectors/opa/lib/opa_reader_test.go
+++ b/connectors/opa/lib/opa_reader_test.go
@@ -44,9 +44,9 @@ func TestMain(m *testing.M) {
 	tu.EnvValues["CATALOG_CONNECTOR_URL"] = "localhost:" + "50084"
 	tu.EnvValues["OPA_SERVER_URL"] = "localhost:" + "8282"
 
-	go tu.MockCatalogConnector("50084")
+	go tu.MockCatalogConnector(50084)
 	time.Sleep(5 * time.Second)
-	go tu.MockOpaServer("8282")
+	go tu.MockOpaServer(8282)
 	time.Sleep(5 * time.Second)
 	code := m.Run()
 	fmt.Println("TestMain function called after Run = opa_connector_test ")

--- a/connectors/opa/testutil/helper.go
+++ b/connectors/opa/testutil/helper.go
@@ -6,6 +6,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"github.com/ibm/the-mesh-for-data/manager/controllers/utils"
 	"log"
 	"net"
 	"net/http"
@@ -166,10 +167,11 @@ func GetCatalogInfo(appId string, datasetID string) *pb.CatalogDatasetInfo {
 	return datasetInfo
 }
 
-func MockCatalogConnector(port string) {
-	log.Println("Start Mock for Catalog Connector at port " + port)
+func MockCatalogConnector(port int) {
+	address := utils.ListeningAddress(port)
+	log.Println("Start Mock for Catalog Connector at " + address)
 
-	lis, err := net.Listen("tcp", ":"+port)
+	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatalf("Error in listening: %v", err)
 	}
@@ -190,9 +192,10 @@ func customOpaResponse(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, customeResponse)
 }
 
-func MockOpaServer(port string) {
-	log.Println("Start Mock for OPA Server at port " + port)
+func MockOpaServer(port int) {
+	address := utils.ListeningAddress(port)
+	log.Println("Start Mock for OPA Server at " + address)
 
 	http.HandleFunc("/v1/data/user_policies", customOpaResponse)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	log.Fatal(http.ListenAndServe(address, nil))
 }


### PR DESCRIPTION
Signed-off-by: Florian Froese <ffr@zurich.ibm.com>

When opening ports on OS X with just ":8282" there will be an annoying popup about firewall rules. To solve this there is a utility that adds changes this to "localhost:8282" for OS X. (It already used in different tests)