### PR TITLE
make: add run-integration-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ test:
 	$(MAKE) -C manager test
 
 .PHONY: run-integration-tests
-run-integration-tests: export DOCKER_HOSTNAME=kind-registry:5000
-run-integration-tests: export DOCKER_NAMESPACE=m4d-system
+run-integration-tests: export DOCKER_HOSTNAME?=kind-registry:5000
+run-integration-tests: export DOCKER_NAMESPACE?=m4d-system
 run-integration-tests:
 	$(MAKE) kind
 	$(MAKE) cluster-prepare

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -123,8 +123,8 @@ wait_for_manager:
 	$(TOOLBIN)/kubectl wait --for=condition=available -n ${KUBE_NAMESPACE} deployment/m4d-controller-manager --timeout=120s
 
 .PHONY: run-integration-tests
-run-integration-tests: export DOCKER_HOSTNAME=kind-registry:5000
-run-integration-tests: export DOCKER_NAMESPACE=m4d-system
+run-integration-tests: export DOCKER_HOSTNAME?=kind-registry:5000
+run-integration-tests: export DOCKER_NAMESPACE?=m4d-system
 run-integration-tests: wait_for_manager
 	NO_SIMULATED_PROGRESS=true USE_EXISTING_CONTROLLER=true USE_EXISTING_CLUSTER=true go test ./... -v -run TestMotionAPIs -count 1
 	NO_SIMULATED_PROGRESS=true USE_EXISTING_CONTROLLER=true USE_EXISTING_CLUSTER=true go test ./... -v -run TestAPIs -count 1


### PR DESCRIPTION
Signed-off-by: hunchback <aidan.shribman@gmail.com>

can be used for local development by running:

```
make run-integration-tests
```

from top-level