### PR TITLE
charts: helm for installing manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ run-integration-tests:
 	$(MAKE) cluster-prepare-wait
 	$(MAKE) -C secret-provider configure-vault
 	$(MAKE) -C secret-provider deploy
+	$(MAKE) -C manager deploy-crd
 	$(MAKE) -C manager deploy_it
 	$(MAKE) -C manager wait_for_manager
 	$(MAKE) helm
@@ -57,6 +58,7 @@ deploy:
 undeploy:
 	$(MAKE) -C secret-provider undeploy
 	$(MAKE) -C manager undeploy
+	$(MAKE) -C manager undeploy-crd
 	$(MAKE) -C connectors undeploy
 
 .PHONY: docker

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,0 +1,12 @@
+ROOT_DIR := ..
+include $(ROOT_DIR)/Makefile.env
+
+.PHONY: run-integration-tests
+run-integration-tests: export ROOT_DIR := .
+run-integration-tests:
+	cd .. && $(MAKE) kind
+	helm install -g m4d-crd
+	kubectl create namespace m4d-system
+	cd ../third_party/cert-manager && $(MAKE) deploy deploy-wait
+	cd ../third_party/vault && $(MAKE) deploy wait_for_vault
+	helm install -g m4d

--- a/charts/m4d/.helmignore
+++ b/charts/m4d/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/m4d/Chart.yaml
+++ b/charts/m4d/Chart.yaml
@@ -1,0 +1,8 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: m4d
+description: M4D Helm Chart
+type: application
+version: 0.0.0

--- a/charts/m4d/templates/_helpers.tpl
+++ b/charts/m4d/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "m4d.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "m4d.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "m4d.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "m4d.labels" -}}
+helm.sh/chart: {{ include "m4d.chart" . }}
+{{ include "m4d.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "m4d.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "m4d.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "m4d.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "m4d.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/m4d/templates/manager.yaml
+++ b/charts/m4d/templates/manager.yaml
@@ -1,0 +1,490 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: m4d-mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: m4d-webhook-service
+      namespace: m4d-system
+      path: /mutate-motion-m4d-ibm-com-v1alpha1-batchtransfer
+  failurePolicy: Fail
+  name: mbatchtransfer.kb.io
+  rules:
+  - apiGroups:
+    - motion.m4d.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - batchtransfers
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: m4d-webhook-service
+      namespace: m4d-system
+      path: /mutate-motion-m4d-ibm-com-v1alpha1-streamtransfer
+  failurePolicy: Fail
+  name: mstreamtransfer.kb.io
+  rules:
+  - apiGroups:
+    - motion.m4d.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - streamtransfers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: m4d-leader-election-role
+  namespace: m4d-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: m4d-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - secrets
+  - secrets/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumeclaims/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - blueprints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - blueprints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - m4dapplications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - m4dapplications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - m4dbuckets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - m4dbuckets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - m4dmodules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - plotters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.m4d.ibm.com
+  resources:
+  - plotters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/finalizers
+  - deployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - jobs/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - motion.m4d.ibm.com
+  resources:
+  - batchtransfers
+  - batchtransfers/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - motion.m4d.ibm.com
+  resources:
+  - batchtransfers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - motion.m4d.ibm.com
+  resources:
+  - streamtransfers
+  - streamtransfers/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - motion.m4d.ibm.com
+  resources:
+  - streamtransfers/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: m4d-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: m4d-leader-election-rolebinding
+  namespace: m4d-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: m4d-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: m4d-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: m4d-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: m4d-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: m4d-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: m4d-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: m4d-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: m4d-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: m4d-controller-manager-metrics-service
+  namespace: m4d-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: m4d-webhook-service
+  namespace: m4d-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: m4d-controller-manager
+  namespace: m4d-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        - --enable-all-controllers
+        env:
+        - name: ENABLE_WEBHOOKS
+          value: "true"
+        - name: MOVER_IMAGE
+          value: {{ .Values.image.mover }}
+        - name: IMAGE_PULL_POLICY
+          value: Always
+        image: {{ .Values.image.manager }}
+        imagePullPolicy: Always
+        name: manager
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: m4d-serving-cert
+  namespace: m4d-system
+spec:
+  dnsNames:
+  - m4d-webhook-service.m4d-system.svc
+  - m4d-webhook-service.m4d-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: m4d-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: m4d-selfsigned-issuer
+  namespace: m4d-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: m4d-validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: m4d-webhook-service
+      namespace: m4d-system
+      path: /validate-motion-m4d-ibm-com-v1alpha1-batchtransfer
+  failurePolicy: Fail
+  name: vbatchtransfer.kb.io
+  rules:
+  - apiGroups:
+    - motion.m4d.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - batchtransfers
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: m4d-webhook-service
+      namespace: m4d-system
+      path: /validate-motion-m4d-ibm-com-v1alpha1-streamtransfer
+  failurePolicy: Fail
+  name: vstreamtransfer.kb.io
+  rules:
+  - apiGroups:
+    - motion.m4d.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - streamtransfers

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -1,0 +1,7 @@
+# Default values for m4d.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+   mover: ghcr.io/the-mesh-for-data/mover:latest
+   manager: ghcr.io/the-mesh-for-data/manager:latest

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -53,10 +53,24 @@ install: $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl manifests
 uninstall: $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl manifests
 	$(TOOLBIN)/kustomize build config/crd | $(TOOLBIN)/kubectl delete -f -
 
+# Install core into charts/m4d
+.PHONY: charts
+charts:
+	cd config/manager && $(ABSTOOLBIN)/kustomize edit set image controller=${IMG}
+	$(TOOLBIN)/kustomize build config/default > $(ROOT_DIR)/charts/m4d/templates/manager.yaml
+
 # Install CRDs into a charts/m4d-crds
 .PHONY: charts-crd
 charts-crd: $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl manifests
 	$(TOOLBIN)/kustomize build config/crd > $(ROOT_DIR)/charts/m4d-crd/templates/crds.yaml
+
+.PHONY: deploy-crd
+deploy-crd:
+	kustomize build config/crd | kubectl apply -f -
+
+.PHONY: undeploy-crd
+undeploy-crd:
+	kustomize build config/crd | kubectl delete -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: docker-secret manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl config/default/kustomization.yaml

--- a/manager/README.md
+++ b/manager/README.md
@@ -36,7 +36,7 @@ Description of configuration folder structure:
 - `config/certmanager`: Creates a certificate that can be used for webhooks
 - `config/control-plane-security`: Applies authorization and authentication policies to secure the control plane. Some of the policies are based on [Istio](https://istio.io/) thus Istio installation is prerequisite for this configuration. It's used in the make target `make deploy_control-plane-security` (in order for the Istio sidecar automatic injection to take effect the pods in the control-plane should be restarted after running the make command).
 - `config/crd`: Contains the generated CRD definition as well as some patches for the webhook of the crd. This gets installed into the cluster when executing `make install`
-- `config/default`: This is the default deployment that deploys everything. This includes the CRD, manager deployment, certificates, rbac rules and webhook. This gets installed into the cluster when executing `make deploy`.
+- `config/default`: This is the default deployment that deploys everything but CRDs. This includes, manager deployment, certificates, rbac rules and webhook. This gets installed into the cluster when executing `make deploy`.
 - `config/manager`: Kustomization of the deployment of the controller of the operator. Just the K8s deployment object of the manager.
 - `config/movement-controller`: This is used to install a controller on K8s that is just managing the motion CRDs and no other CRDs. 
   it's used in the make target `make deploy_mc` (the movement-controller image must already be available in an image registry)

--- a/manager/config/default/kustomization.yaml.in
+++ b/manager/config/default/kustomization.yaml.in
@@ -16,7 +16,6 @@ namePrefix: m4d-
 #  someName: someValue
 
 bases:
-- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml


### PR DESCRIPTION
created a helm chart for installing the manager to used with:

```
helm install -g m4d
```

for testing purposes (to be optimized and put in the CI in a later phase):

```
cd charts
make run-integration-tests
```