### PR TITLE
Charts cert-manager

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,12 +1,35 @@
 ROOT_DIR := ..
 include $(ROOT_DIR)/Makefile.env
 
+.PHONY: kind
+kind: export ROOT_DIR := .
+kind:
+	cd .. && $(MAKE) kind
+
+.PHONY: cert-manager
+cert-manager:
+	@echo "Installing cert-manager ..."
+	kubectl create namespace cert-manager
+	helm repo add jetstack https://charts.jetstack.io
+	helm repo update
+	helm install cert-manager jetstack/cert-manager \
+	  --namespace cert-manager --version v1.1.0 --set installCRDs=true \
+	  --wait --timeout 120s
+
+.PHONY: vault
+vault:
+	@echo "Installing vault ..."
+	cd ../third_party/vault && $(MAKE) deploy deploy-wait
+
+.PHONY: m4d
+m4d:
+	@echo "installing m4d ..."
+	kubectl create namespace m4d-system || true
+	helm install m4d-crd m4d-crd \
+		--namespace m4d-system --wait --timeout 120s
+	helm install m4d m4d \
+		--namespace m4d-system --wait --timeout 120s
+
 .PHONY: run-integration-tests
 run-integration-tests: export ROOT_DIR := .
-run-integration-tests:
-	cd .. && $(MAKE) kind
-	helm install -g m4d-crd
-	kubectl create namespace m4d-system
-	cd ../third_party/cert-manager && $(MAKE) deploy deploy-wait
-	cd ../third_party/vault && $(MAKE) deploy deploy-wait
-	helm install -g m4d
+run-integration-tests: kind cert-manager vault m4d


### PR DESCRIPTION
Add to the charts makefile a set of commands based on `helm` and `kubectl` to handle deployment of cert-manager, such that we can provide a sequence which does not require a `git clone` of our tree and running `make` commands