### PR TITLE
travis: replace integration tests implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,17 +76,7 @@ jobs:
     install:
     - make install-tools
     script:
-    - make kind-setup || travis_terminate 1; # Switch to make kind when istio is needed
-    - make cluster-prepare || travis_terminate 1;
-    - make docker
-    - make -C test/services docker-all # Build test services
-    - make cluster-prepare-wait || travis_terminate 1;
-    - make -C secret-provider configure-vault
-    - make -C secret-provider deploy || travis_terminate 1;
-    - make -C manager deploy_it || travis_terminate 1;
-    - make -C manager wait_for_manager || travis_terminate 1;
-    - make helm || travis_terminate 1;
-    - make -C manager run-integration-tests || travis_terminate 1;
+    - make run-integration-tests
     deploy:
      skip_cleanup: true
      provider: script


### PR DESCRIPTION
minor change, call integrations tests target directly instead of re-implementation within travis.yaml