### PR TITLE
vault: refactor

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -8,5 +8,5 @@ run-integration-tests:
 	helm install -g m4d-crd
 	kubectl create namespace m4d-system
 	cd ../third_party/cert-manager && $(MAKE) deploy deploy-wait
-	cd ../third_party/vault && $(MAKE) deploy wait_for_vault
+	cd ../third_party/vault && $(MAKE) deploy deploy-wait
 	helm install -g m4d

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -8,7 +8,7 @@ set -e
 : ${WITHOUT_EGERIA:=false}
 : ${WITHOUT_OPA:=false}
 
-source third_party/vault/vault-util.sh
+source secret-provider/deploy/vault-util.sh
 
 kubectl create ns $KUBE_NAMESPACE || true
 
@@ -22,7 +22,7 @@ $WITHOUT_EGERIA || make -C third_party/egeria deploy
 $WITHOUT_OPA || make -C third_party/opa deploy
 
 # Waiting for the vault deployment to become ready
-make -C third_party/vault wait_for_vault
+make -C third_party/vault deploy-wait
 
 # Perform a port-forward to communicate with Vault
 port_forward

--- a/secret-provider/deploy/deploy.sh
+++ b/secret-provider/deploy/deploy.sh
@@ -8,7 +8,7 @@ set -e
 : ${KUBE_NAMESPACE:=m4d-system}
 : ${WITHOUT_VAULT=true}
 
-source ../../third_party/vault/vault-util.sh
+source vault-util.sh
 
 kustomize_build() {
         local operation=$1

--- a/secret-provider/deploy/vault-util.sh
+++ b/secret-provider/deploy/vault-util.sh
@@ -125,16 +125,6 @@ create_policy() {
 #EOF
 }
 
-# We're using old-school while b/c we can't wait on object that haven't been created, and we can't know for sure that the statefulset had been created so far
-# See https://github.com/kubernetes/kubernetes/issues/75227
-wait_for_vault() {
-  while [[ $(kubectl get -n $KUBE_NAMESPACE pods -l statefulset.kubernetes.io/pod-name=vault-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]];
-  do
-      echo "waiting for vault pod to become ready" 
-      sleep 5
-  done
-}
-
 # Do port-forwarding, if needed
 port_forward() {
   # Port forward, so we could access vault
@@ -144,9 +134,6 @@ port_forward() {
 }
 
 configure_path() {
-  # Make sure the vault pod is ready
-  wait_for_vault
-  
   $WITHOUT_PORT_FORWARD || port_forward
   # Get Vault's root token
   export VAULT_TOKEN=$(kubectl get secrets vault-unseal-keys -n $KUBE_NAMESPACE -o jsonpath={.data.vault-root} | base64 --decode)

--- a/third_party/vault/Makefile
+++ b/third_party/vault/Makefile
@@ -8,14 +8,15 @@ KUBE_NAMESPACE ?= m4d-system
 deploy:
 	./deploy.sh deploy
 
-.PHONY: deploy-wait
-deploy-wait: $(TOOLBIN)/kubectl
-	$(TOOLBIN)/kubectl wait --for=condition=ready -n ${KUBE_NAMESPACE} pod/vault-0 --timeout=180s
-
 .PHONY: undeploy
 undeploy:
 	./deploy.sh undeploy
 
-.PHONY: wait_for_vault
-wait_for_vault:
-	./deploy.sh wait_for_vault
+.PHONY: deploy-wait
+deploy-wait:
+	# We're using old-school while b/c we can't wait on object that haven't been created, and we can't know for sure that the statefulset had been created so far
+	# See https://github.com/kubernetes/kubernetes/issues/75227
+	while [[ $$(kubectl get -n ${KUBE_NAMESPACE} pods -l statefulset.kubernetes.io/pod-name=vault-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do \
+	    echo "waiting for vault pod to become ready"; \
+	    sleep 5; \
+	done

--- a/third_party/vault/deploy.sh
+++ b/third_party/vault/deploy.sh
@@ -37,11 +37,8 @@ case "$1" in
     undeploy)
         undeploy
         ;;
-    wait_for_vault)
-      wait_for_vault
-      ;;
     *)
-        echo "usage: $0 [deploy|undeploy|wait_for_vault]"
+        echo "usage: $0 [deploy|undeploy]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
cleanup vault deployment:
- leave only stuff related to deployment of the service
- move the secret-provider what is related to its' setup