### PR TITLE
replacing read module with dummy for testing

### DIFF
--- a/manager/testdata/e2e/module-read.yaml
+++ b/manager/testdata/e2e/module-read.yaml
@@ -11,7 +11,7 @@ metadata:
     version: 0.0.1  # semantic version
 spec:
   chart:
-    name: ghcr.io/the-mesh-for-data/arrow-flight-module-chart:latest
+    name: kind-registry:5000/m4d-system/m4d-template:0.1.0
   type: service
   flows:
     - read


### PR DESCRIPTION
Fixes https://github.com/IBM/the-mesh-for-data/issues/220

This PR replaces a real arrow-flight module chart by a dummy m4d-template module.
