### PR TITLE
make: add run-deploy-tests target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,17 +101,10 @@ jobs:
 
   - stage: Deploy
     name: "Kind deploy"
-    env:
-    - COMPONENT=connectors
-    - CLUSTER=kind
     install:
     - make install-tools
     script:
-    - make $CLUSTER || travis_terminate 1;
-    - make cluster-prepare || travis_terminate 1;
-    - make -C third_party/opa deploy || travis_terminate 1;
-    - make -C $COMPONENT deploy
-    - ./hack/tools/bin/kubectl get pod --all-namespaces
+    - make run-deploy-tests
     if: branch = master AND type = push
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,17 @@ run-integration-tests:
 	$(MAKE) helm
 	$(MAKE) -C manager run-integration-tests
 
+.PHONY: run-deploy-tests
+run-deploy-tests:
+	$(MAKE) kind
+	$(MAKE) cluster-prepare
+	$(MAKE) -C third_party/opa deploy
+	kubectl apply -f ./manager/config/prod/deployment_configmap.yaml
+	kubectl create secret generic user-vault-unseal-keys --from-literal=user-vault-root=''
+	$(MAKE) -C connectors deploy
+	kubectl get pod --all-namespaces
+	kubectl wait --for=condition=ready pod --all-namespaces --all --timeout=120s
+
 .PHONY: cluster-prepare
 cluster-prepare:
 	$(MAKE) -C third_party/cert-manager deploy


### PR DESCRIPTION
the deploy phase in travis was silently failing (as described in the associated issue), as a result there is no guarantee that the images placed in the public docker repo are actually ok and can execute.