### PR TITLE
Create ISSUE_TEMPLATE/config.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Ask a Question
+      url: https://github.com/IBM/the-mesh-for-data/discussions/new?category=help
+      about: Ask the community for help
+    - name: Feature Request
+      url: https://github.com/IBM/the-mesh-for-data/discussions/new?category=ideas
+      about: Share ideas for new features
+    - name: Bug Report
+      url: https://github.com/IBM/the-mesh-for-data/issues/new
+      about: Report a reproducable bug


### PR DESCRIPTION
Fixes #246

Opening an issue will show this (the first two opens a discussion with the matching category instead of an issue):
![image](https://user-images.githubusercontent.com/321048/103477216-34859d80-4dc5-11eb-81b2-7347f171e259.png)

