### PR TITLE
Generate a plotter for a single cluster config as well

### DIFF
--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -314,7 +314,7 @@ func (r *M4DApplicationReconciler) ConstructDataInfo(datasetID string, req *modu
 
 // NewM4DApplicationReconciler creates a new reconciler for M4DApplications
 func NewM4DApplicationReconciler(mgr ctrl.Manager, name string, vaultClient *api.Client,
-	policyCompiler pc.IPolicyCompiler, context ContextInterface, cm multicluster.ClusterLister) *M4DApplicationReconciler {
+	policyCompiler pc.IPolicyCompiler, cm multicluster.ClusterLister) *M4DApplicationReconciler {
 	return &M4DApplicationReconciler{
 		Client:            mgr.GetClient(),
 		Name:              name,
@@ -322,7 +322,7 @@ func NewM4DApplicationReconciler(mgr ctrl.Manager, name string, vaultClient *api
 		Scheme:            mgr.GetScheme(),
 		VaultClient:       vaultClient,
 		PolicyCompiler:    policyCompiler,
-		ResourceInterface: context,
+		ResourceInterface: NewPlotterInterface(mgr.GetClient()),
 		ClusterManager:    cm,
 	}
 }

--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -530,7 +530,6 @@ var _ = Describe("M4DApplication Controller", func() {
 
 			// work-around: we don't have currently a setup for multicluster environment in tests
 			if os.Getenv("USE_EXISTING_CONTROLLER") == "true" {
-				By("Expecting an error")
 				Eventually(func() string {
 					f := &apiv1alpha1.M4DApplication{}
 					_ = k8sClient.Get(context.Background(), appSignature, f)
@@ -541,7 +540,7 @@ var _ = Describe("M4DApplication Controller", func() {
 			} else {
 				Eventually(func() *apiv1alpha1.ResourceReference {
 					f := &apiv1alpha1.M4DApplication{}
-					Expect(k8sClient.Get(context.Background(), appSignature, f)).To(Succeed())
+					_ = k8sClient.Get(context.Background(), appSignature, f)
 					resource = f
 					return f.Status.Generated
 				}, timeout, interval).ShouldNot(BeNil())

--- a/manager/controllers/app/suite_test.go
+++ b/manager/controllers/app/suite_test.go
@@ -96,13 +96,7 @@ var _ = BeforeSuite(func(done Done) {
 		policyCompiler := &mockup.MockPolicyCompiler{}
 		// Initiate the M4DApplication Controller
 		var clusterManager *mockup.ClusterLister
-		var resourceContext ContextInterface
-		if os.Getenv("MULTI_CLUSTERED_CONFIG") == "true" {
-			resourceContext = NewPlotterInterface(mgr.GetClient())
-		} else {
-			resourceContext = NewBlueprintInterface(mgr.GetClient())
-		}
-		err = NewM4DApplicationReconciler(mgr, "M4DApplication", nil, policyCompiler, resourceContext, clusterManager).SetupWithManager(mgr)
+		err = NewM4DApplicationReconciler(mgr, "M4DApplication", nil, policyCompiler, clusterManager).SetupWithManager(mgr)
 		Expect(err).ToNot(HaveOccurred())
 		err = NewBlueprintReconciler(mgr, "Blueprint", fakeHelm).SetupWithManager(mgr)
 		Expect(err).ToNot(HaveOccurred())

--- a/manager/controllers/mockup/mockup_cluster_lister.go
+++ b/manager/controllers/mockup/mockup_cluster_lister.go
@@ -4,8 +4,6 @@
 package mockup
 
 import (
-	"os"
-
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
 )
 
@@ -15,22 +13,14 @@ type ClusterLister struct {
 
 // GetClusters returns the cluster config for testing
 func (m *ClusterLister) GetClusters() ([]multicluster.Cluster, error) {
-	if os.Getenv("MULTI_CLUSTERED_CONFIG") == "true" {
-		return []multicluster.Cluster{
-			{
-				Name:     "US-cluster",
-				Metadata: multicluster.ClusterMetadata{Region: "US"},
-			},
-			{
-				Name:     "Germany-cluster",
-				Metadata: multicluster.ClusterMetadata{Region: "Germany"},
-			},
-		}, nil
-	}
 	return []multicluster.Cluster{
 		{
 			Name:     "US-cluster",
 			Metadata: multicluster.ClusterMetadata{Region: "US"},
+		},
+		{
+			Name:     "Germany-cluster",
+			Metadata: multicluster.ClusterMetadata{Region: "Germany"},
 		},
 	}, nil
 }

--- a/manager/main.go
+++ b/manager/main.go
@@ -129,13 +129,7 @@ func main() {
 		policyCompiler := pc.NewPolicyCompiler()
 
 		// Initiate the M4DApplication Controller
-		var resourceContext app.ContextInterface
-		if os.Getenv("MULTI_CLUSTERED_CONFIG") == "true" {
-			resourceContext = app.NewPlotterInterface(mgr.GetClient())
-		} else {
-			resourceContext = app.NewBlueprintInterface(mgr.GetClient())
-		}
-		applicationController := app.NewM4DApplicationReconciler(mgr, "M4DApplication", vaultClient, policyCompiler, resourceContext, clusterManager)
+		applicationController := app.NewM4DApplicationReconciler(mgr, "M4DApplication", vaultClient, policyCompiler, clusterManager)
 		if err := applicationController.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "M4DApplication")
 			os.Exit(1)

--- a/pkg/multicluster/local/local_cluster_manager.go
+++ b/pkg/multicluster/local/local_cluster_manager.go
@@ -2,10 +2,14 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	"github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -13,11 +17,13 @@ const (
 	clusterMetadataConfigmapName string = "cluster-metadata"
 )
 
+// ClusterManager for local cluster configuration
 type ClusterManager struct {
 	Client    client.Client
 	Namespace string
 }
 
+// GetClusters returns a list of registered clusters
 func (cm *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
 	clusterMetadataConfigmap := corev1.ConfigMap{}
 	namespacedName := client.ObjectKey{
@@ -40,22 +46,68 @@ func (cm *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
 	return clusters, nil
 }
 
+// GetLocalClusterName returns the local cluster name
+func (cm *ClusterManager) GetLocalClusterName() (string, error) {
+	clusters, err := cm.GetClusters()
+	if err != nil {
+		return "", err
+	}
+	if len(clusters) != 1 {
+		return "", errors.New(v1alpha1.InvalidClusterConfiguration)
+	}
+	return clusters[0].Name, nil
+}
+
+// GetBlueprint returns a blueprint matching the given name, namespace and cluster details
 func (cm *ClusterManager) GetBlueprint(cluster string, namespace string, name string) (*v1alpha1.Blueprint, error) {
-	return nil, nil
+	if localCluster, err := cm.GetLocalClusterName(); err != nil || localCluster != cluster {
+		return nil, errors.New("Unregistered cluster: " + cluster)
+	}
+	blueprint := &v1alpha1.Blueprint{}
+	namespacedName := client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	err := cm.Client.Get(context.Background(), namespacedName, blueprint)
+	return blueprint, err
 }
 
+// CreateBlueprint creates a blueprint resource or updates an existing one
 func (cm *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
-	return nil
+	return cm.UpdateBlueprint(cluster, blueprint)
 }
 
+// UpdateBlueprint updates the given blueprint or creates a new one if does not exist
 func (cm *ClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+	if localCluster, err := cm.GetLocalClusterName(); err != nil || localCluster != cluster {
+		return errors.New("Unregistered cluster: " + cluster)
+	}
+	resource := &v1alpha1.Blueprint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      blueprint.Name,
+			Namespace: blueprint.Namespace,
+		},
+	}
+	if _, err := ctrl.CreateOrUpdate(context.Background(), cm.Client, resource, func() error {
+		resource.Spec = blueprint.Spec
+		return nil
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 
+// DeleteBlueprint deletes the blueprint resource
 func (cm *ClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
-	return nil
+	blueprint, err := cm.GetBlueprint(cluster, namespace, name)
+	if err != nil {
+		return err
+	}
+	return cm.Client.Delete(context.Background(), blueprint)
 }
 
+// NewManager creates a new ClusterManager for a local cluster configuration
 func NewManager(client client.Client, namespace string) multicluster.ClusterManager {
 	return &ClusterManager{
 		Client:    client,


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com 
Fixes https://github.com/IBM/the-mesh-for-data/issues/256

- M4dapplication controller will always create a Plotter resource
- Local cluster manager implements missing ClusterManager methods (GetBlueprint, CreateBlueprint, ...)
- Removed MULT_CLUSTERED_CONFIG
