### PR TITLE
Docker mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
     install:
     - make install-tools
     script:
+    - make docker-mirror-read
     - make test
 
   # FIXME(hunchback): disabled as its' taking 15m to run
@@ -76,6 +77,7 @@ jobs:
     install:
     - make install-tools
     script:
+    - make docker-mirror-read
     - make run-integration-tests
     deploy:
      skip_cleanup: true
@@ -104,6 +106,7 @@ jobs:
     install:
     - make install-tools
     script:
+    - make docker-mirror-read
     - make run-deploy-tests
     if: branch = master AND type = push
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ license: $(TOOLBIN)/license_finder
 	$(call license_go,.)
 	$(call license_python,secret-provider)
 
+.PHONY: docker-mirror-read
+docker-mirror-read:
+	$(TOOLS_DIR)/docker_mirror.sh $(TOOLS_DIR)/docker_mirror.conf
+
 .PHONY: build
 build:
 	$(MAKE) -C pkg/policy-compiler build

--- a/hack/tools/docker_mirror.conf
+++ b/hack/tools/docker_mirror.conf
@@ -1,0 +1,14 @@
+alpine:latest
+banzaicloud/bank-vaults:master
+kindest/kindnetd:0.5.4
+kindest/node:v1.16.9
+library/vault:1.3.1
+openjdk:8u131-jre-alpine
+openpolicyagent/kube-mgmt:0.11
+openpolicyagent/opa:latest
+prom/statsd-exporter:latest
+python:3.6
+python:3.6-slim
+rancher/local-path-provisioner:v0.0.12
+registry:2
+vault:1.3.1

--- a/hack/tools/docker_mirror.sh
+++ b/hack/tools/docker_mirror.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+imagesfile=$1
+
+SOURCE=${SOURCE:-docker.io}
+MIRROR=${MIRROR:-quay.io/ibm}
+
+readarray -t IMAGES < $imagesfile
+
+do_pull_retag() {
+	m=$1
+	s=$2
+	docker pull $m 2>/dev/null || return
+	docker tag $m $s 2>/dev/null
+	echo "$ docker pull $m"
+	echo "$ docker tag $m $s"
+	echo
+}
+
+mirror_pull_and_retag_to_source() {
+	for s in ${IMAGES[@]}; do
+		tag=${s#*:}
+		[[ $s == '/' ]] && namespace=${s#\/*}
+		name=${s#*\/}
+		name=${name%:*} # remove suffix
+		[ -n "$namespace" ] && do_pull_retag $MIRROR/$namespace-$name-x86_64:$tag $SOURCE/$s && continue
+		[ -n "$namespace" ] && do_pull_retag $MIRROR/$namespace-$name-x86_64:latest $SOURCE/$s && continue
+		[ -z "$namespace" ] && do_pull_retag $MIRROR/$name-x86_64:$tag $SOURCE/$s && continue
+		[ -z "$namespace" ] && do_pull_retag $MIRROR/$name-x86_64:latest $SOURCE/$s && continue
+	done
+}
+
+mirror_pull_and_retag_to_source


### PR DESCRIPTION
solve docker.io rate limit by using github registry to populate the docker cache (currently only for builds but later also for the registry serving k8s).

when wanting to use the cache (and bypass docker.io) then run:

```
make docker-mirror-read
```