### PR TITLE
Shorten module release name

### DIFF
--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -120,17 +120,8 @@ func (r *BlueprintReconciler) reconcileFinalizers(blueprint *app.Blueprint) (ctr
 }
 
 func getReleaseName(blueprintName string, step app.FlowStep) string {
-	// we add the "r" character at the beginning of the release name, since it must begin with an alphabetic character
 	fullName := blueprintName + "-" + step.Name
-	if len(fullName) > 53 { // Some k8s objects only allow for a length of 63 characters. This is why we restrict it here
-		// The new name is formed from a prefix which is formed from the full name to have some human readable
-		// form of the name and the postfix which is the last characters hashed to have some shorter identifier
-		// that is still deterministic given the full name.
-		prefix := fullName[:47]
-		postfix := utils.Hash(fullName[:47], 5)
-		return prefix + "-" + postfix
-	}
-	return fullName
+	return utils.HelmConformName(fullName)
 }
 
 func (r *BlueprintReconciler) deleteExternalResources(blueprint *app.Blueprint) error {

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -122,12 +122,12 @@ func (r *BlueprintReconciler) reconcileFinalizers(blueprint *app.Blueprint) (ctr
 func getReleaseName(blueprintName string, step app.FlowStep) string {
 	// we add the "r" character at the beginning of the release name, since it must begin with an alphabetic character
 	fullName := blueprintName + "-" + step.Name
-	if len(fullName) > 63 { // Some k8s objects only allow for a length of 63 characters. This is why we restrict it here
+	if len(fullName) > 53 { // Some k8s objects only allow for a length of 63 characters. This is why we restrict it here
 		// The new name is formed from a prefix which is formed from the full name to have some human readable
 		// form of the name and the postfix which is the last characters hashed to have some shorter identifier
 		// that is still deterministic given the full name.
-		prefix := fullName[:57]
-		postfix := utils.Hash(fullName[:57], 5)
+		prefix := fullName[:47]
+		postfix := utils.Hash(fullName[:47], 5)
 		return prefix + "-" + postfix
 	}
 	return fullName

--- a/manager/controllers/app/blueprint_controller_test.go
+++ b/manager/controllers/app/blueprint_controller_test.go
@@ -137,12 +137,12 @@ var _ = Describe("Blueprint Controller", func() {
 
 			relName := getReleaseName(blueprint.Name, blueprint.Spec.Flow.Steps[0])
 			Expect(relName).To(Equal("appnsisalreadylong-appnameisevenlonger-myblueprintnameisr-5950f"))
-			Expect(relName).To(HaveLen(63))
+			Expect(relName).To(HaveLen(53))
 
 			// Make sure that calling the same method again results in the same result
 			relName2 := getReleaseName(blueprint.Name, blueprint.Spec.Flow.Steps[0])
 			Expect(relName2).To(Equal("appnsisalreadylong-appnameisevenlonger-myblueprintnameisr-5950f"))
-			Expect(relName2).To(HaveLen(63))
+			Expect(relName2).To(HaveLen(53))
 		})
 	})
 })

--- a/manager/controllers/app/blueprint_controller_test.go
+++ b/manager/controllers/app/blueprint_controller_test.go
@@ -136,12 +136,12 @@ var _ = Describe("Blueprint Controller", func() {
 			}
 
 			relName := getReleaseName(blueprint.Name, blueprint.Spec.Flow.Steps[0])
-			Expect(relName).To(Equal("appnsisalreadylong-appnameisevenlonger-myblueprintnameisr-5950f"))
+			Expect(relName).To(Equal("appnsisalreadylong-appnameisevenlonger-mybluepr-58392"))
 			Expect(relName).To(HaveLen(53))
 
 			// Make sure that calling the same method again results in the same result
 			relName2 := getReleaseName(blueprint.Name, blueprint.Spec.Flow.Steps[0])
-			Expect(relName2).To(Equal("appnsisalreadylong-appnameisevenlonger-myblueprintnameisr-5950f"))
+			Expect(relName2).To(Equal("appnsisalreadylong-appnameisevenlonger-mybluepr-58392"))
 			Expect(relName2).To(HaveLen(53))
 		})
 	})

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -123,6 +123,33 @@ func CreateAppIdentifier(application *app.M4DApplication) string {
 	return application.Namespace + "/" + application.Name
 }
 
+// Some k8s objects only allow for a length of 63 characters.
+// This method shortens the name keeping a prefix and using the last 5 characters of the
+// new name for the hash of the postfix.
+func K8sConformName(name string) string {
+	return ShortenedName(name, 63, 5)
+}
+
+// Helm has stricter restrictions than K8s and restricts release names to 53 characters
+func HelmConformName(name string) string {
+	return ShortenedName(name, 53, 5)
+}
+
+// This function shortens a name to the maximum length given and uses rest of the string that is too long
+// as hash that gets added to the valid name.
+func ShortenedName(name string, maxLength int, hashLength int) string {
+	if len(name) > maxLength {
+		// The new name is formed from a prefix which is formed from the full name to have some human readable
+		// form of the name and the postfix which is the last characters hashed to have some shorter identifier
+		// that is still deterministic given the full name.
+		cutOffIndex := maxLength - hashLength - 1
+		prefix := name[:cutOffIndex]
+		postfix := Hash(name[:cutOffIndex], hashLength)
+		return prefix + "-" + postfix
+	}
+	return name
+}
+
 func ListeningAddress(port int) string {
 	address := fmt.Sprintf(":%d", port)
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
Helm has a restriction on 53 characters for a release name instead of the 63 characters restriction that K8s has. As the modules are based on helm we'll have to restrict on 53 characters.