### PR TITLE
helm push fix: x509: certificate relies on legacy Common Name field

### DIFF
--- a/hack/make-rules/helm.mk
+++ b/hack/make-rules/helm.mk
@@ -6,6 +6,7 @@ HELM_RELEASE ?= rel1-${DOCKER_NAME}
 TEMP := /tmp
 
 export HELM_EXPERIMENTAL_OCI=1
+export GODEBUG=x509ignoreCN=0
 
 .PHONY: helm-login
 helm-login: $(TOOLBIN)/helm


### PR DESCRIPTION
fix bug in helm push to local registry, fixing `make run-integration-tests` stage