### PR TITLE
fixing vault-connector deployment

### DIFF
--- a/connectors/vault/vault_connector.yaml
+++ b/connectors/vault/vault_connector.yaml
@@ -34,7 +34,7 @@ spec:
         - name: USER_VAULT_TOKEN
           valueFrom:
             secretKeyRef:
-              name: vault-unseal-keys
+              name: user-vault-unseal-keys
               key: vault-root
 ---
 apiVersion: v1

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -11,11 +11,11 @@ set -e
 source secret-provider/deploy/vault-util.sh
 
 kubectl create ns $KUBE_NAMESPACE || true
+kubectl config set-context --current --namespace=$KUBE_NAMESPACE
 
-kubectl apply -f manager/config/prod/deployment_configmap.yaml -n $KUBE_NAMESPACE
-
+kubectl apply -f manager/config/prod/deployment_configmap.yaml
 make cluster-prepare
-
+kubectl create secret generic user-vault-unseal-keys --from-literal=vault-root=$(kubectl get secrets vault-unseal-keys -o jsonpath={.data.vault-root} | base64 --decode) || true
 # Install third party components
 $WITHOUT_VAULT || make -C third_party/vault deploy
 $WITHOUT_EGERIA || make -C third_party/egeria deploy


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@m4d.sl.cloud9.ibm.com>

This PR fixes the run-deploy-tests that was failing due to the missing secret.
User vault secret is reverted to user-vault-unseal-keys to enable deploying the vault connector in m4d-system and dealing with both vault secrets.
Both run-deploy-tests and hack/install.sh install connectors explicitly in KUBE_NAMESPACE. When the deployed namespace will be a part of the connector deployment, this will change.