### PR TITLE
charts: add opa-connector to m4d helm

### DIFF
--- a/charts/m4d/templates/opa_connector.yaml
+++ b/charts/m4d/templates/opa_connector.yaml
@@ -1,0 +1,45 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.opaConnector }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opa-connector
+  labels:
+    app: opa-connector
+spec:
+  selector:
+    matchLabels:
+      app: opa-connector
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: opa-connector
+        m4d.ibm.com/componentType: connector
+    spec:
+      containers:
+      - name: opa-connector
+        image: {{ .Values.image.opaConnector }}
+        imagePullPolicy: {{ .Values.image.opaConnectorPullPolicy }}
+        ports:
+        - name: opa-connector
+          containerPort: 50082
+        envFrom:
+        - configMapRef:
+            name: m4d-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa-connector
+spec:
+  selector:
+    app: opa-connector
+  ports:
+  - port: 50082
+    targetPort: opa-connector
+{{- end }}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -4,8 +4,11 @@
 
 global:
   opa: true
+  opaConnector: true
 
 image:
    mover: ghcr.io/the-mesh-for-data/mover:latest
    manager: ghcr.io/the-mesh-for-data/manager:latest
    secretProvider: ghcr.io/the-mesh-for-data/secret-provider:latest
+   opaConnector: ghcr.io/the-mesh-for-data/opa-connector:latest
+   opaConnectorPullPolicy: IfNotPresent


### PR DESCRIPTION
this PR adds the opa-connector as default for the m4d helm chart, the location of the opa-connector docker images can be controlled via values.yaml:

```
image:
  opaConnector: <image location goes here>
```

other than that there is not change to the m4d helm chart.