### PR TITLE
Remove dev requirements for local registry setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ addons:
       - conntrack
       - ethtool
       - apache2-utils
-  hosts:
-  - kind-registry
 
 os:
 - linux
@@ -72,7 +70,7 @@ jobs:
   - stage: Test
     name: "Integration tests for manager in kind"
     env:
-    - DOCKER_HOSTNAME=kind-registry:5000
+    - DOCKER_HOSTNAME=localhost:5000
     - DOCKER_NAMESPACE=m4d-system
     install:
     - make install-tools

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 	$(MAKE) -C manager test
 
 .PHONY: run-integration-tests
-run-integration-tests: export DOCKER_HOSTNAME?=kind-registry:5000
+run-integration-tests: export DOCKER_HOSTNAME?=localhost:5000
 run-integration-tests: export DOCKER_NAMESPACE?=m4d-system
 run-integration-tests:
 	$(MAKE) kind

--- a/hack/setup-local-multi-cluster.sh
+++ b/hack/setup-local-multi-cluster.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # This script is meant for local development with kind
 
-export DOCKER_HOSTNAME=kind-registry:5000
+export DOCKER_HOSTNAME=localhost:5000
 export DOCKER_NAMESPACE=m4d-system
 export HELM_EXPERIMENTAL_OCI=1
 

--- a/hack/tools/create_kind.sh
+++ b/hack/tools/create_kind.sh
@@ -38,8 +38,6 @@ kind_create() {
     --image=kindest/node:$K8S_VERSION
   for node in $(kind get nodes --name $1); do
     bin/kubectl annotate node "${node}" "tilt.dev/registry=localhost:5000" --context kind-${1}
-    docker cp ../registry/themeshfordata-ca.crt "$node":/usr/local/share/ca-certificates
-    docker exec "$node" update-ca-certificates
   done
 }
 

--- a/hack/tools/create_kind.sh
+++ b/hack/tools/create_kind.sh
@@ -11,111 +11,55 @@ source ./common.sh
 K8S_VERSION=${K8S_VERSION:-v1.16.9}
 
 registry_delete() {
-    docker network disconnect kind kind-registry
-    docker kill kind-registry
-    docker rm -f kind-registry
+  docker network disconnect kind kind-registry
+  docker kill kind-registry
+  docker rm -f kind-registry
 }
 
 registry_create() {
-        running="$(docker inspect -f '{{.State.Running}}' "kind-registry" 2>/dev/null || true)"
-        if [ "${running}" != 'true' ]; then
-          docker run \
-            -d --restart=always -p "5000:5000" --name "kind-registry" \
-            --network kind \
-            -v ${PWD}/../registry:/registry \
-            -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
-            -e REGISTRY_HTTP_TLS_CERTIFICATE=/registry/registry.crt \
-            -e REGISTRY_HTTP_TLS_KEY=/registry/registry.key \
-            registry:2
-        fi
-}
-
-certs_create() {
-    mkdir -p ../registry || true
-
-    if [ ! -f ../registry/themeshfordata-ca.crt ]; then
-      openssl genrsa -out ../registry/themeshfordata-ca.key 2048
-      openssl req -new -x509 -key ../registry/themeshfordata-ca.key -out ../registry/themeshfordata-ca.crt -subj '/C=US/ST=NY/O=IBM/CN=themeshfordata' -extensions EXT -config <(printf "[dn]\nCN=ibm\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:ibm\nbasicConstraints=CA:TRUE,pathlen:0")
-    fi
-    if [ ! -f ../registry/registry.crt ]; then
-      openssl genrsa -out ../registry/registry.key 2048
-      openssl req -new -key ../registry/registry.key -out ../registry/registry.csr -subj '/C=US/ST=NY/O=IBM/CN=kind-registry' -extensions EXT -config <(printf "[dn]\nCN=kind-registry\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:kind-registry,DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
-      openssl x509 -req -in ../registry/registry.csr -CA ../registry/themeshfordata-ca.crt -CAkey ../registry/themeshfordata-ca.key -CAcreateserial -out ../registry/registry.crt
-    fi
-}
-
-install_certs() {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # This has been tested on Ubuntu. On other distributions this may vary.
-        # If developers use different distributions please add a branch here that works.
-        sudo cp ../registry/themeshfordata-ca.crt /usr/local/share/ca-certificates
-	      sudo update-ca-certificates --fresh
-	  elif [[ "$OSTYPE" == "darwin"* ]]; then
-	      VALIDCERT=0
-	      security verify-cert -k /Users/ffr/Library/Keychains/login.keychain-db -c ../registry/registry.crt || VALIDCERT=$?
-        if [ $VALIDCERT -eq 0 ]; then
-          echo Certificate already valid!
-        else
-          echo OSX will ask to provide your password in order to install the CA certificate to keychain!
-          # Installs the CA certificate to the user local keychain
-          security add-trusted-cert -r trustRoot -k ~/Library/Keychains/login.keychain-db -e hostnameMismatch ../registry/themeshfordata-ca.crt
-        fi
-    else
-        echo Please install the certificates in $PWD/../registry/themeshfordata-ca.crt !
-    fi
-}
-
-certs_delete() {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      # This has been tested on Ubuntu. On other distributions this may vary.
-      # If developers use different distributions please add a branch here that works.
-      sudo rm /usr/local/share/ca-certificates/themeshfordata-ca.crt
-      sudo update-ca-certificates --fresh
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-      security remove-trusted-cert  ../registry/themeshfordata-ca.crt
-      security delete-certificate -c themeshfordata
-    fi
-    rm -rf ../registry || exit 1
+  running="$(docker inspect -f '{{.State.Running}}' "kind-registry" 2>/dev/null || true)"
+  if [ "${running}" != 'true' ]; then
+    docker run \
+      -d --restart=always -p "5000:5000" --name "kind-registry" \
+      --network kind \
+      -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
+      registry:2
+  fi
 }
 
 kind_delete() {
-        bin/kind delete cluster --name $1
+  bin/kind delete cluster --name $1
 }
 
 kind_create() {
-        bin/kind create cluster --name $1 \
-             -v 4 --retain --wait=0s \
-             --config ./$2 \
-             --image=kindest/node:$K8S_VERSION
-        for node in $(kind get nodes --name $1); do
-          bin/kubectl annotate node "${node}" "tilt.dev/registry=kind-registry:5000" --context kind-${1};
-          docker cp ../registry/themeshfordata-ca.crt "$node":/usr/local/share/ca-certificates
-          docker exec "$node" update-ca-certificates
-        done
+  bin/kind create cluster --name $1 \
+    -v 4 --retain --wait=0s \
+    --config ./$2 \
+    --image=kindest/node:$K8S_VERSION
+  for node in $(kind get nodes --name $1); do
+    bin/kubectl annotate node "${node}" "tilt.dev/registry=localhost:5000" --context kind-${1}
+    docker cp ../registry/themeshfordata-ca.crt "$node":/usr/local/share/ca-certificates
+    docker exec "$node" update-ca-certificates
+  done
 }
 
 case "$op" in
-    cleanup)
-        header_text "Uninstalling kind cluster"
-        registry_delete || true
-        certs_delete || true
-        kind_delete kind || true
-        kind_delete control || true
-        ;;
-    multi)
-        header_text "Installing kind multi-cluster"
-        certs_create
-        install_certs
-        kind_create kind kind-config.yaml &
-        kind_create control kind-control-config.yaml &
-        wait
-        registry_create
-        ;;
-    *)
-        header_text "Installing kind cluster"
-        certs_create
-        install_certs
-        kind_create kind kind-config.yaml
-        registry_create
-        ;;
+cleanup)
+  header_text "Uninstalling kind cluster"
+  registry_delete || true
+  kind_delete kind || true
+  kind_delete control || true
+  ;;
+multi)
+  header_text "Installing kind multi-cluster"
+  kind_create kind kind-config.yaml &
+  kind_create control kind-control-config.yaml &
+  wait
+  registry_create
+  ;;
+*)
+  header_text "Installing kind cluster"
+  kind_create kind kind-config.yaml
+  registry_create
+  ;;
 esac

--- a/hack/tools/docker_mirror.conf
+++ b/hack/tools/docker_mirror.conf
@@ -12,3 +12,4 @@ python:3.6-slim
 rancher/local-path-provisioner:v0.0.12
 registry:2
 vault:1.3.1
+alpine/socat:latest

--- a/hack/tools/docker_mirror.conf
+++ b/hack/tools/docker_mirror.conf
@@ -1,4 +1,5 @@
 alpine:latest
+alpine/socat:latest
 banzaicloud/bank-vaults:master
 kindest/kindnetd:0.5.4
 kindest/node:v1.16.9
@@ -12,4 +13,3 @@ python:3.6-slim
 rancher/local-path-provisioner:v0.0.12
 registry:2
 vault:1.3.1
-alpine/socat:latest

--- a/hack/tools/kind-config.yaml
+++ b/hack/tools/kind-config.yaml
@@ -9,4 +9,4 @@ nodes:
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["https://kind-registry:5000"]
+    endpoint = ["http://kind-registry:5000"]

--- a/hack/tools/kind-control-config.yaml
+++ b/hack/tools/kind-control-config.yaml
@@ -14,4 +14,4 @@ nodes:
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["https://kind-registry:5000"]
+    endpoint = ["http://kind-registry:5000"]

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -142,7 +142,7 @@ wait_for_manager: $(TOOLBIN)/kubectl
 	$(TOOLBIN)/kubectl wait --for=condition=available -n ${KUBE_NAMESPACE} deployment/m4d-controller-manager --timeout=120s
 
 .PHONY: run-integration-tests
-run-integration-tests: export DOCKER_HOSTNAME?=kind-registry:5000
+run-integration-tests: export DOCKER_HOSTNAME?=localhost:5000
 run-integration-tests: export DOCKER_NAMESPACE?=m4d-system
 run-integration-tests: wait_for_manager
 	NO_SIMULATED_PROGRESS=true USE_EXISTING_CONTROLLER=true USE_EXISTING_CLUSTER=true go test ./... -v -run TestMotionAPIs -count 1

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -105,8 +105,6 @@ undeploy_mc: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl config/default/ku
 	$(TOOLBIN)/kustomize build --load_restrictor none config/movement-controller | $(TOOLBIN)/kubectl delete -f -
 
 deploy_it: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl config/default/kustomization.yaml 
-	make build-ca-certs
-	make deploy-custom-ca-secret
 	$(TOOLBIN)/kubectl create namespace ${KUBE_NAMESPACE} || true
 	$(TOOLBIN)/kubectl create namespace m4d-blueprints || true
 	cd config/manager && $(ABSTOOLBIN)/kustomize edit set image controller=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/manager:${DOCKER_TAGNAME}
@@ -115,8 +113,6 @@ deploy_it: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl config/default/kust
 	$(TOOLBIN)/kustomize build --load_restrictor none config/integration-tests | $(TOOLBIN)/kubectl apply -f -
 
 deploy_multi_it: manifests $(TOOLBIN)/kustomize $(TOOLBIN)/kubectl config/default/kustomization.yaml
-	make build-ca-certs
-	make deploy-custom-ca-secret
 	$(TOOLBIN)/kubectl create namespace ${KUBE_NAMESPACE} || true
 	$(TOOLBIN)/kubectl create namespace m4d-blueprints || true
 	cd config/manager && $(ABSTOOLBIN)/kustomize edit set image controller=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/manager:${DOCKER_TAGNAME}
@@ -150,23 +146,6 @@ run-integration-tests: wait_for_manager
 
 .PHONY: main.deps
 main.deps: generate fmt vet manifests
-
-# Download CA certificates from manager image and add the CA certificate that was generated for the test.
-# This file is then uploaded to K8s as a secret and injected into the manager during deployment.
-# This way the image of the manger is not altered and still only contains the CA certificates from the base image.
-.PHONY: build-ca-certs
-build-ca-certs: $(TOOLBIN)/kubectl
-	rm $(ROOT_DIR)/hack/registry/ca-certificates.crt || true
-	# Hack to fetch CA certificates of base image
-	bash -c "docker cp $$(docker create --rm $(DOCKER_HOSTNAME)/$(DOCKER_NAMESPACE)/$(DOCKER_NAME):$(DOCKER_TAGNAME)):/etc/ssl/certs/ca-certificates.crt $(ROOT_DIR)/hack/registry/ca-certificates.crt"
-	cat $(ROOT_DIR)/hack/registry/themeshfordata-ca.crt >> $(ROOT_DIR)/hack/registry/ca-certificates.crt
-
-.PHONY: deploy-custom-ca-secret
-deploy-custom-ca-secret: $(TOOLBIN)/kubectl
-	$(ABSTOOLBIN)/kubectl create secret generic registry-ca-cert \
-		--from-file=../hack/registry/ca-certificates.crt \
-		--namespace ${KUBE_NAMESPACE} \
-		|| true
 
 DEBUG := ./debug.out
 

--- a/manager/config/integration-tests/kustomization.yaml
+++ b/manager/config/integration-tests/kustomization.yaml
@@ -17,8 +17,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: data-catalog-mock
-  newName: kind-registry:5000/m4d-system/data-catalog-mock
+  newName: localhost:5000/m4d-system/data-catalog-mock
   newTag: latest
 - name: policycompiler
-  newName: kind-registry:5000/m4d-system/serverpolicycompiler-mock
+  newName: localhost:5000/m4d-system/serverpolicycompiler-mock
   newTag: latest

--- a/manager/config/integration-tests/manager_patch.yaml
+++ b/manager/config/integration-tests/manager_patch.yaml
@@ -31,13 +31,3 @@ spec:
           value: "false"
         - name: GODEBUG
           value: "x509ignoreCN=0"
-        volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-certificates.crt
-          subPath: ca-certificates.crt
-          name: ca-cert
-          readOnly: true
-      volumes:
-      - name: ca-cert
-        secret:
-          defaultMode: 420
-          secretName: registry-ca-cert

--- a/manager/config/integration-tests/manager_patch.yaml
+++ b/manager/config/integration-tests/manager_patch.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: integration-tests
-        image: alpine/socat:1.0.5
+        image: alpine/socat:latest
         command:
         - socat
         - TCP4-LISTEN:5000,fork

--- a/manager/config/integration-tests/manager_patch.yaml
+++ b/manager/config/integration-tests/manager_patch.yaml
@@ -12,13 +12,19 @@ spec:
   template:
     spec:
       containers:
+      - name: integration-tests
+        image: alpine/socat:latest
+        command:
+        - socat
+        - TCP4-LISTEN:5000,fork
+        - TCP4:kind-registry:5000
       - name: manager
         imagePullPolicy: Always
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
         - name: MOVER_IMAGE
-          value: "kind-registry:5000/m4d-system/dummy-mover:latest"
+          value: "localhost:5000/m4d-system/dummy-mover:latest"
         - name: IMAGE_PULL_POLICY
           value: "IfNotPresent"
         - name: NO_FINALIZER

--- a/manager/config/integration-tests/manager_patch.yaml
+++ b/manager/config/integration-tests/manager_patch.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: integration-tests
-        image: alpine/socat:latest
+        image: alpine/socat:1.0.5
         command:
         - socat
         - TCP4-LISTEN:5000,fork

--- a/manager/config/manager/kustomization.yaml
+++ b/manager/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/the-mesh-for-data/manager
+  newName: localhost:5000/m4d-system/manager
   newTag: latest

--- a/manager/config/multi-controller/kustomization.yaml
+++ b/manager/config/multi-controller/kustomization.yaml
@@ -14,8 +14,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: data-catalog-mock
-  newName: kind-registry:5000/m4d-system/data-catalog-mock
+  newName: localhost:5000/m4d-system/data-catalog-mock
   newTag: latest
 - name: policycompiler
-  newName: kind-registry:5000/m4d-system/serverpolicycompiler-mock
+  newName: localhost:5000/m4d-system/serverpolicycompiler-mock
   newTag: latest

--- a/manager/config/multi-follower/kustomization.yaml
+++ b/manager/config/multi-follower/kustomization.yaml
@@ -14,8 +14,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: data-catalog-mock
-  newName: kind-registry:5000/m4d-system/data-catalog-mock
+  newName: localhost:5000/m4d-system/data-catalog-mock
   newTag: latest
 - name: policycompiler
-  newName: kind-registry:5000/m4d-system/serverpolicycompiler-mock
+  newName: localhost:5000/m4d-system/serverpolicycompiler-mock
   newTag: latest

--- a/manager/config/multi-integration-tests/kustomization.yaml
+++ b/manager/config/multi-integration-tests/kustomization.yaml
@@ -15,8 +15,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: data-catalog-mock
-  newName: kind-registry:5000/m4d-system/data-catalog-mock
+  newName: localhost:5000/m4d-system/data-catalog-mock
   newTag: latest
 - name: policycompiler
-  newName: kind-registry:5000/m4d-system/serverpolicycompiler-mock
+  newName: localhost:5000/m4d-system/serverpolicycompiler-mock
   newTag: latest

--- a/manager/config/multi-integration-tests/manager_patch.yaml
+++ b/manager/config/multi-integration-tests/manager_patch.yaml
@@ -18,7 +18,7 @@ spec:
         - name: ENABLE_WEBHOOKS
           value: "true"
         - name: MOVER_IMAGE
-          value: "kind-registry:5000/m4d-system/dummy-mover:latest"
+          value: "localhost:5000/m4d-system/dummy-mover:latest"
         - name: IMAGE_PULL_POLICY
           value: "IfNotPresent"
         - name: NO_FINALIZER

--- a/manager/testdata/batchtransfer.yaml
+++ b/manager/testdata/batchtransfer.yaml
@@ -31,7 +31,7 @@ spec:
       algo: md5
   secretProviderURL: "http://secret-provider.secret-provider.svc.cluster.local:5555/get-secret"
   secretProviderRole: demo
-  image: kind-registry:5000/m4d-system/dummy-mover:latest
+  image: localhost:5000/m4d-system/dummy-mover:latest
   imagePullPolicy: "IfNotPresent"
   maxFailedRetries: 0
   successfulJobHistoryLimit: 3

--- a/manager/testdata/blueprint.yaml
+++ b/manager/testdata/blueprint.yaml
@@ -52,4 +52,4 @@ spec:
     kind: M4DModule
     flow: copy
     chart:
-      name: kind-registry:5000/m4d-system/m4d-db2wh:0.1.0
+      name: localhost:5000/m4d-system/m4d-db2wh:0.1.0

--- a/manager/testdata/e2e/module-implicit-copy-db2wh-to-s3.yaml
+++ b/manager/testdata/e2e/module-implicit-copy-db2wh-to-s3.yaml
@@ -82,7 +82,7 @@ spec:
       name: "encrypt"
       level: 2 # column
   chart:
-    name: kind-registry:5000/m4d-system/m4d-db2wh:0.1.0
+    name: localhost:5000/m4d-system/m4d-db2wh:0.1.0
     values:
       image: ghcr.io/the-mesh-for-data/mover:latest
   statusIndicators:

--- a/manager/testdata/e2e/module-implicit-copy-kafka-to-s3-stream.yaml
+++ b/manager/testdata/e2e/module-implicit-copy-kafka-to-s3-stream.yaml
@@ -82,7 +82,7 @@ spec:
       name: "encrypt"
       level: 2 # column
   chart:
-    name: kind-registry:5000/m4d-system/m4d-kafka:0.1.0
+    name: localhost:5000/m4d-system/m4d-kafka:0.1.0
     values:
       image: ghcr.io/the-mesh-for-data/mover:latest
   statusIndicators:

--- a/manager/testdata/e2e/module-read.yaml
+++ b/manager/testdata/e2e/module-read.yaml
@@ -11,7 +11,7 @@ metadata:
     version: 0.0.1  # semantic version
 spec:
   chart:
-    name: kind-registry:5000/m4d-system/m4d-template:0.1.0
+    name: localhost:5000/m4d-system/m4d-template:0.1.0
   type: service
   flows:
     - read

--- a/manager/testdata/plotter.yaml
+++ b/manager/testdata/plotter.yaml
@@ -42,5 +42,5 @@ spec:
       - kind: M4DModule
         name: implicit-copy-db2wh-to-s3-latest
         chart:
-          name: kind-registry:5000/m4d-system/m4d-db2wh:0.1.0
+          name: localhost:5000/m4d-system/m4d-db2wh:0.1.0
   selector: {}

--- a/manager/testdata/streamtransfer.yaml
+++ b/manager/testdata/streamtransfer.yaml
@@ -31,7 +31,7 @@ spec:
       algo: md5
   secretProviderURL: "http://secret-provider.secret-provider.svc.cluster.local:5555/get-secret"
   secretProviderRole: demo
-  image: kind-registry:5000/m4d-system/dummy-mover:latest
+  image: localhost:5000/m4d-system/dummy-mover:latest
   imagePullPolicy: "IfNotPresent"
   maxFailedRetries: 0
   successfulJobHistoryLimit: 3

--- a/modules/m4d-db2wh/values.yaml.sample
+++ b/modules/m4d-db2wh/values.yaml.sample
@@ -1,4 +1,4 @@
-image: kind-registry:5000/m4d-system/dummy-mover:latest
+image: localhost:5000/m4d-system/dummy-mover:latest
 imagePullSecret: IfNotPresent
 
 copy:

--- a/modules/m4d-kafka/values.yaml.sample
+++ b/modules/m4d-kafka/values.yaml.sample
@@ -1,4 +1,4 @@
-image: kind-registry:5000/m4d-system/dummy-mover:latest
+image: localhost:5000/m4d-system/dummy-mover:latest
 
 copy:
   source:

--- a/modules/m4d-s3-to-s3/values.yaml.sample
+++ b/modules/m4d-s3-to-s3/values.yaml.sample
@@ -1,4 +1,4 @@
-image: "kind-registry:5000/m4d-system/mover:latest"
+image: "localhost:5000/m4d-system/mover:latest"
 imagePullPolicy: "IfNotPresent"
 noFinalizer: "true"
 

--- a/secret-provider/deploy/base/kustomization.yaml
+++ b/secret-provider/deploy/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 - secret-provider-rbac.yaml
 images:
 - name: secret-provider
-  newName: kind-registry:5000/m4d-system/secret-provider
+  newName: localhost:5000/m4d-system/secret-provider

--- a/website/content/contribute/code/flow/index.md
+++ b/website/content/contribute/code/flow/index.md
@@ -85,19 +85,6 @@ USE_EXISTING_CONTROLLER=true NO_SIMULATED_PROGRESS=true USE_EXISTING_CLUSTER=tru
 
 # Running integration tests
 
-## Pre requisite
-
-The integration tests make use of the local docker registry such enables using
-current docker images (rather than official images) during tests. The docker
-registry runs on localhost:5000 but in order that it be accessible from within
-the k8s cluster it has to be designated a FQDN named `kind-registry`.
-
-To support local image registry host resolution append the following to /etc/hosts:
-
-```
-127.0.0.1       kind-registry
-```
-
 ## Running in one step
 
 With the following you will then setup a kind cluster with the local registry,


### PR DESCRIPTION
Fixes #310 

- [X] Changed local registry address to localhost:5000 
- [X] Changed integration-tests Kustomize layer to run a `alpine/socat` sidecar to allow manager container to access to the registry over localhost
- [X] docs: Removed `Pre requisite` section from `/contribute/code/flow.md`
- [X] Fixed formatting issues in create_kind.sh using [shell-format](https://github.com/mvdan/sh#related-projects) (it was hard to modify it without). This seems to follow the google style guide. If vim `=G` is preferred then I can use that for now until we have a standard defined although I don't see common support for it in other IDEs.
- [x] Mirror alpine/socat to quay.io 