### PR TITLE
charts: add to m4d extraArgs/extraEnvs

### DIFF
--- a/charts/m4d/templates/manager.yaml
+++ b/charts/m4d/templates/manager.yaml
@@ -407,8 +407,9 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
-        - --enable-all-controllers
+      {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 8 }}
+      {{- end }}
         env:
         - name: VAULT_TOKEN
           valueFrom:
@@ -421,6 +422,9 @@ spec:
           value: {{ .Values.image.mover }}
         - name: IMAGE_PULL_POLICY
           value: Always
+      {{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
+      {{- end }}
         image: {{ .Values.image.manager }}
         imagePullPolicy: Always
         name: manager

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -12,3 +12,13 @@ image:
    secretProvider: ghcr.io/the-mesh-for-data/secret-provider:latest
    opaConnector: ghcr.io/the-mesh-for-data/opa-connector:latest
    opaConnectorPullPolicy: IfNotPresent
+
+# extraArgs to be passed to manager container
+extraArgs:
+  - --enable-leader-election
+  - --enable-all-controllers
+
+# extraEnvs to be set for manager container
+extraEnvs: []
+# - name: env_name
+#   value: env_value


### PR DESCRIPTION
this PR addresses a subset of issue #317 

to enable future customization of the the manager to support various deployment modes I have added to values.yaml two expansion/customization options:
- extraArgs - add extra arguments to be passed to the manager container
- extraEnvs - pass extra environment variables for the manager container

the basic approach has been taken from what is generally accepted for helm charts such as is used for example in the elastic/elasticsearch helm chart https://github.com/elastic/helm-charts/blob/master/elasticsearch/values.yaml#L35 (many more similar examples exist)

to verify that there has been no degradation due to the change I ran:

```
aidan@AIDANSHRIBMAN-SDFUE6N:~/projects/the-mesh-for-data/charts$ helm install m4d m4d         --namespace m4d-system
NAME: m4d
LAST DEPLOYED: Wed Feb  3 10:32:57 2021
NAMESPACE: m4d-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```