### PR TITLE
Modifying copy module helm resources to support lack of transformations

### DIFF
--- a/modules/m4d-db2wh/templates/batchtransfer.yaml
+++ b/modules/m4d-db2wh/templates/batchtransfer.yaml
@@ -19,6 +19,7 @@ spec:
       dataFormat: "{{ .Values.copy.destination.format }}"
       vaultPath: "{{ .Values.copy.destination.credentialLocation }}"
   transformation:
+  {{ if .Values.copy.transformations }}
   {{ range .Values.copy.transformations }}
   {{ if eq .id "redact-ID" }}
   - action: "RedactColumns"
@@ -31,6 +32,7 @@ spec:
   - action: "RemoveColumns"
     name: "redacting column: {{ .args.column_name }}"
     columns: [ "{{ .args.column_name }}" ]
+  {{ end }}
   {{ end }}
   {{ end }}
   {{ if .Values.image }}

--- a/modules/m4d-db2wh/templates/batchtransfer.yaml
+++ b/modules/m4d-db2wh/templates/batchtransfer.yaml
@@ -18,8 +18,8 @@ spec:
       objectKey: "{{ .Values.copy.destination.connection.s3.object_key }}"
       dataFormat: "{{ .Values.copy.destination.format }}"
       vaultPath: "{{ .Values.copy.destination.credentialLocation }}"
-  transformation:
   {{ if .Values.copy.transformations }}
+  transformation:
   {{ range .Values.copy.transformations }}
   {{ if eq .id "redact-ID" }}
   - action: "RedactColumns"

--- a/modules/m4d-kafka/templates/streamtransfer.yaml
+++ b/modules/m4d-kafka/templates/streamtransfer.yaml
@@ -30,8 +30,8 @@ spec:
       objectKey: "{{ .Values.copy.destination.connection.s3.object_key }}"
       dataFormat: "{{ .Values.copy.destination.format }}"
       vaultPath: "{{ .Values.copy.destination.credentialLocation }}"
-  transformation:
   {{ if .Values.copy.transformations }}
+  transformation:
   {{ range .Values.copy.transformations }}
   {{ if eq .id "redact-ID" }}
   - action: "RedactColumns"

--- a/modules/m4d-kafka/templates/streamtransfer.yaml
+++ b/modules/m4d-kafka/templates/streamtransfer.yaml
@@ -31,6 +31,7 @@ spec:
       dataFormat: "{{ .Values.copy.destination.format }}"
       vaultPath: "{{ .Values.copy.destination.credentialLocation }}"
   transformation:
+  {{ if .Values.copy.transformations }}
   {{ range .Values.copy.transformations }}
   {{ if eq .id "redact-ID" }}
   - action: "RedactColumns"
@@ -43,6 +44,7 @@ spec:
   - action: "RemoveColumns"
     name: "redacting column: {{ .args.column_name }}"
     columns: [ "{{ .args.column_name }}" ]
+  {{ end }}
   {{ end }}
   {{ end }}
   triggerInterval: "10 seconds"

--- a/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
+++ b/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
@@ -26,6 +26,7 @@ spec:
       dataFormat: "{{ .Values.copy.destination.format }}"
       vaultPath: "{{ .Values.copy.destination.credentialLocation }}"
   transformation:
+  {{ if .Values.copy.transformations }}
   {{ range .Values.copy.transformations }}
   {{ if eq .id "redact-ID" }}
   - action: "RedactColumns"
@@ -38,6 +39,7 @@ spec:
   - action: "RemoveColumns"
     name: "redacting column: {{ .args.column_name }}"
     columns: [ "{{ .args.column_name }}" ]
+  {{ end }}
   {{ end }}
   {{ end }}
   {{ if .Values.image }}

--- a/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
+++ b/modules/m4d-s3-to-s3/templates/batchtransfer.yaml
@@ -25,8 +25,8 @@ spec:
       objectKey: "{{ .Values.copy.destination.connection.s3.object_key }}"
       dataFormat: "{{ .Values.copy.destination.format }}"
       vaultPath: "{{ .Values.copy.destination.credentialLocation }}"
-  transformation:
   {{ if .Values.copy.transformations }}
+  transformation:
   {{ range .Values.copy.transformations }}
   {{ if eq .id "redact-ID" }}
   - action: "RedactColumns"


### PR DESCRIPTION
When no transformations are required, helm installation fails with the following error:
 `BatchTransfer.motion.m4d.ibm.com <name> is invalid: spec.transformation: Invalid value: "null": spec.transformation in body must be of type array: "null"`

This PR checks whether transformations exist before creating spec.transformation field. 