### PR TITLE
[RFC] Configure Vault to support K8S auth method in multi-cluster setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ run-integration-tests:
 	$(MAKE) docker
 	$(MAKE) -C test/services docker-all
 	$(MAKE) cluster-prepare-wait
+	$(MAKE) configure-vault
 	$(MAKE) -C secret-provider configure-vault
 	$(MAKE) -C secret-provider deploy
 	$(MAKE) -C manager deploy-crd
@@ -49,6 +50,7 @@ run-deploy-tests:
 	$(MAKE) -C connectors deploy
 	kubectl get pod --all-namespaces
 	kubectl wait --for=condition=ready pod --all-namespaces --all --timeout=120s
+	$(MAKE) configure-vault
 
 .PHONY: cluster-prepare
 cluster-prepare:
@@ -149,3 +151,4 @@ endif
 include hack/make-rules/tools.mk
 include hack/make-rules/verify.mk
 include hack/make-rules/cluster.mk
+include hack/make-rules/vault.mk

--- a/hack/make-rules/vault.mk
+++ b/hack/make-rules/vault.mk
@@ -1,0 +1,15 @@
+.PHONY: vault-setup
+vault-setup: $(TOOLBIN)/vault $(TOOLBIN)/kubectl
+	cd $(TOOLS_DIR); ./configure_vault_kind.sh
+
+.PHONY: vault-setup-multi
+vault-setup-multi: $(TOOLBIN)/vault $(TOOLBIN)/kubectl
+	cd $(TOOLS_DIR); ./configure_vault_kind.sh multi
+
+.PHONY: vault-cleanup
+vault-cleanup: $(TOOLBIN)/vault $(TOOLBIN)/kubectl
+	cd $(TOOLS_DIR); ./configure_vault_kind.sh cleanup
+
+.PHONY: configure-vault
+configure-vault: vault-cleanup vault-setup
+

--- a/hack/tools/configure_vault_kind.sh
+++ b/hack/tools/configure_vault_kind.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+
+op=$1
+
+source ./common.sh
+source ./vault_utils.sh
+
+: ${KUBE_NAMESPACE:=m4d-system}
+: ${INGRESS_ADDRESS:=localhost:80}
+: ${KIND_CLUSTER_KUBE_HOST:=https://kind-control-plane:6443}
+: ${CONTROL_CLUSTER_KUBE_HOST:=https://control-control-plane:6443}
+: ${MODULE_NAMESPACE:="m4d-blueprints"}
+: ${SECRET_PATH:=m4d/dataset-creds}
+: ${ROLE:=module}
+
+
+# $1 - cluster name
+# $2 - vault root token
+# $3 - vault address
+# $4 - kube host of the cluster
+enable_k8s_auth_for_cluster() {
+        kubectl config use-context kind-"$1"
+        kubectl create ns $KUBE_NAMESPACE || true
+        kubectl apply -f vault_auth_sa.yaml -n "$KUBE_NAMESPACE"
+        enable_k8s_auth "$2" "$1" vault-auth "$KUBE_NAMESPACE" "$3" "$4"
+}
+
+# $1 - vault root token
+# $2 - vault address
+configure_vault() {
+	enable_kv "$SECRET_PATH" "$1" "$2"
+	create_policy "allow-all-$SECRET_PATH" "$SECRET_PATH/*" "$1" "$2"
+}
+
+
+# $1 - cluster name
+# $2 - vault root token
+# $3 - vault address
+add_role() {
+	create_role "$ROLE" "$2" "allow-all-$SECRET_PATH" "$1" "$3" "$MODULE_NAMESPACE"
+}
+
+case "$op" in
+    cleanup)
+        ;;
+    multi)
+        header_text "Configure Vault on kind multi-cluster"
+        kubectl config use-context kind-control --namespace=$KUBE_NAMESPACE
+        export VAULT_TOKEN=$(kubectl get secrets vault-unseal-keys -n $KUBE_NAMESPACE -o jsonpath={.data.vault-root} | base64 --decode)
+        enable_k8s_auth_for_cluster control "$VAULT_TOKEN" "$INGRESS_ADDRESS" "$CONTROL_CLUSTER_KUBE_HOST"
+        enable_k8s_auth_for_cluster kind "$VAULT_TOKEN" "$INGRESS_ADDRESS" "$KIND_CLUSTER_KUBE_HOST"
+	configure_vault "$VAULT_TOKEN" "$INGRESS_ADDRESS"
+	add_role kind "$VAULT_TOKEN" "$INGRESS_ADDRESS"
+        add_role control "$VAULT_TOKEN" "$INGRESS_ADDRESS"
+        ;;
+    *)
+        header_text "Configure Vault on kind cluster"
+        kubectl config use-context kind-kind --namespace=$KUBE_NAMESPACE
+        export VAULT_TOKEN=$(kubectl get secrets vault-unseal-keys -n $KUBE_NAMESPACE -o jsonpath={.data.vault-root} | base64 --decode)
+        port_forward
+	enable_k8s_auth_for_cluster kind "$VAULT_TOKEN"  'http://127.0.0.1:8200' "$KIND_CLUSTER_KUBE_HOST"
+	configure_vault "$VAULT_TOKEN" 'http://127.0.0.1:8200'
+	add_role kind "$VAULT_TOKEN" 'http://127.0.0.1:8200'
+        # Kill the port-forward if nessecarry
+        kill -9 %%
+        ;;
+esac
+

--- a/hack/tools/configure_vault_kind.sh
+++ b/hack/tools/configure_vault_kind.sh
@@ -49,8 +49,8 @@ case "$op" in
         bin/vault login "$VAULT_TOKEN"
         enable_k8s_auth_for_cluster control "$CONTROL_CLUSTER_KUBE_HOST"
         enable_k8s_auth_for_cluster kind "$KIND_CLUSTER_KUBE_HOST"
-	configure_vault
-	add_role kind
+        configure_vault
+        add_role kind
         add_role control
         ;;
     *)

--- a/hack/tools/configure_vault_kind.sh
+++ b/hack/tools/configure_vault_kind.sh
@@ -10,7 +10,7 @@ source ./common.sh
 source ./vault_utils.sh
 
 : ${KUBE_NAMESPACE:=m4d-system}
-: ${INGRESS_ADDRESS:=localhost:80}
+: ${INGRESS_ADDRESS:=http://localhost:80}
 : ${KIND_CLUSTER_KUBE_HOST:=https://kind-control-plane:6443}
 : ${CONTROL_CLUSTER_KUBE_HOST:=https://control-control-plane:6443}
 : ${MODULE_NAMESPACE:="m4d-blueprints"}
@@ -19,29 +19,23 @@ source ./vault_utils.sh
 
 
 # $1 - cluster name
-# $2 - vault root token
-# $3 - vault address
-# $4 - kube host of the cluster
+# $2 - kube host of the cluster
 enable_k8s_auth_for_cluster() {
         kubectl config use-context kind-"$1"
         kubectl create ns $KUBE_NAMESPACE || true
         kubectl apply -f vault_auth_sa.yaml -n "$KUBE_NAMESPACE"
-        enable_k8s_auth "$2" "$1" vault-auth "$KUBE_NAMESPACE" "$3" "$4"
+        enable_k8s_auth "$1" vault-auth "$KUBE_NAMESPACE" "$2"
 }
 
-# $1 - vault root token
-# $2 - vault address
 configure_vault() {
-	enable_kv "$SECRET_PATH" "$1" "$2"
-	create_policy "allow-all-$SECRET_PATH" "$SECRET_PATH/*" "$1" "$2"
+	enable_kv "$SECRET_PATH"
+	create_policy "allow-all-$SECRET_PATH" "$SECRET_PATH/*"
 }
 
 
 # $1 - cluster name
-# $2 - vault root token
-# $3 - vault address
 add_role() {
-	create_role "$ROLE" "$2" "allow-all-$SECRET_PATH" "$1" "$3" "$MODULE_NAMESPACE"
+	create_role "$ROLE" "allow-all-$SECRET_PATH" "$1" "$MODULE_NAMESPACE"
 }
 
 case "$op" in
@@ -50,21 +44,25 @@ case "$op" in
     multi)
         header_text "Configure Vault on kind multi-cluster"
         kubectl config use-context kind-control --namespace=$KUBE_NAMESPACE
+        export VAULT_ADDR=$INGRESS_ADDRESS
         export VAULT_TOKEN=$(kubectl get secrets vault-unseal-keys -n $KUBE_NAMESPACE -o jsonpath={.data.vault-root} | base64 --decode)
-        enable_k8s_auth_for_cluster control "$VAULT_TOKEN" "$INGRESS_ADDRESS" "$CONTROL_CLUSTER_KUBE_HOST"
-        enable_k8s_auth_for_cluster kind "$VAULT_TOKEN" "$INGRESS_ADDRESS" "$KIND_CLUSTER_KUBE_HOST"
-	configure_vault "$VAULT_TOKEN" "$INGRESS_ADDRESS"
-	add_role kind "$VAULT_TOKEN" "$INGRESS_ADDRESS"
-        add_role control "$VAULT_TOKEN" "$INGRESS_ADDRESS"
+        bin/vault login "$VAULT_TOKEN"
+        enable_k8s_auth_for_cluster control "$CONTROL_CLUSTER_KUBE_HOST"
+        enable_k8s_auth_for_cluster kind "$KIND_CLUSTER_KUBE_HOST"
+	configure_vault
+	add_role kind
+        add_role control
         ;;
     *)
         header_text "Configure Vault on kind cluster"
         kubectl config use-context kind-kind --namespace=$KUBE_NAMESPACE
         export VAULT_TOKEN=$(kubectl get secrets vault-unseal-keys -n $KUBE_NAMESPACE -o jsonpath={.data.vault-root} | base64 --decode)
         port_forward
-	enable_k8s_auth_for_cluster kind "$VAULT_TOKEN"  'http://127.0.0.1:8200' "$KIND_CLUSTER_KUBE_HOST"
-	configure_vault "$VAULT_TOKEN" 'http://127.0.0.1:8200'
-	add_role kind "$VAULT_TOKEN" 'http://127.0.0.1:8200'
+        export VAULT_ADDR="http://127.0.0.1:8200"
+        bin/vault login "$VAULT_TOKEN"
+	enable_k8s_auth_for_cluster kind "$KIND_CLUSTER_KUBE_HOST"
+	configure_vault
+	add_role kind
         # Kill the port-forward if nessecarry
         kill -9 %%
         ;;

--- a/hack/tools/ingress-nginx.yaml
+++ b/hack/tools/ingress-nginx.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: vault-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /v1/*
+        backend:
+          serviceName: vault
+          servicePort: 8200

--- a/hack/tools/kind-control-config.yaml
+++ b/hack/tools/kind-control-config.yaml
@@ -5,7 +5,19 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
   extraPortMappings:
+  - containerPort: 80 # for Kind ingress
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443 # for Kind ingress
+    hostPort: 443
+    protocol: TCP
   - containerPort: 30333  # Razee dash API node port in K8s
     hostPort: 3333  # Razee dash API on host
   - containerPort: 30080  # Razee dash UI node port in K8s

--- a/hack/tools/vault_auth_sa.yaml
+++ b/hack/tools/vault_auth_sa.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: m4d-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-auth
+  namespace: m4d-system
+  annotations:
+    kubernetes.io/service-account.name: vault-auth
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault-auth
+    namespace: m4d-system

--- a/hack/tools/vault_utils.sh
+++ b/hack/tools/vault_utils.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+: ${PORT_TO_FORWARD:=8200}
+
+# $1 role name
+# $2 Vault token
+# $3 policy name
+# $4 path to auth method
+# $5 vault address
+# $6 bound_service_account_namespaces
+create_role() {
+        # Configure a role for the secret-provider
+        echo "creating role $1 in k8s auth"
+        curl \
+        --header "X-Vault-Token: $2" \
+        --request POST \
+        --data '{"bound_service_account_names": "*", "bound_service_account_namespaces": "'$6'", "policies": "'$1'", "ttl": "24h"}' \
+        "$5"/v1/auth/$4/role/"$1"
+}
+
+# $1 - the path of the secret
+# $2 - the secret, as json
+# $3 - vault-token
+# $4 - vault address
+push_secret() {
+        curl \
+        -H "X-Vault-Token: $3" \
+        -H "Content-Type: application/json" \
+        -X POST \
+        -d "$2" \
+        "$4"/v1/"$1"
+}
+
+enable_kv() {
+        # Enable kv engine to write secrets to vault
+        echo "enabling kv engine for endpoint: $1"
+
+        # Enable the secret endpoint
+        curl \
+        --header "X-Vault-Token: $2" \
+        --request POST \
+        --data '{"type": "kv", "options": {"version": "1"} }' \
+        "$3"/v1/sys/mounts/"$1"
+
+        # Equivalent using the CLI:
+        # vault secrets enable -path=$2 -version=1 kv
+}
+
+# $1 - vault-token
+# $2 - cluster path in vault
+# $3 - vault sa secret name
+# $4 - vault sa secret namespace
+# $5 - vault address
+# $6 - kube host
+enable_k8s_auth() {
+        # Enable k8s service account token auth
+        echo "enabling k8s auth $1 $2 $3 $4"
+        curl \
+        --header "X-Vault-Token: $1" \
+        --request POST \
+        --data '{"type": "kubernetes"}' \
+        "$5"/v1/sys/auth/"$2"
+
+        # Equivalent using the CLI:
+        # vault auth enable <auth path>
+
+        TOKEN_REVIEW_JWT=$(kubectl get secret $3 -n $4 -o jsonpath="{.data.token}" | base64 --decode)
+        KUBE_CA_CERT=$(jq -n --arg cert "$(kubectl get secret $3 -n $4 -o jsonpath="{.data['ca\.crt']}" | base64 --decode)" '$cert')
+
+        # Configure the k8s sa auth
+        echo "configuring k8s auth"
+        curl \
+        --header "X-Vault-Token: $1" \
+        --request POST \
+        --data '{"token_reviewer_jwt":"'"$TOKEN_REVIEW_JWT"'", "kubernetes_ca_cert":'"$KUBE_CA_CERT"', "kubernetes_host":"'"$6"'"}' \
+        "$5"/v1/auth/"$2"/config
+}
+
+
+# $1 - policy name
+# $2 - path
+# $3 - vault-token
+# $4 - vault address
+create_policy() {
+        echo "creating policy $1, to access the secrets in: $2 $3 "
+        curl \
+        --header "X-Vault-Token: $3" \
+        --request PUT \
+        --data '{"policy": "path \"'$2'\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }"}' \
+        "$4"/v1/sys/policy/"$1"
+        # Equivalent using the CLI:
+        # vault policy write "$1" - <<EOF
+}
+
+# Do port-forwarding
+port_forward() {
+        # Port forward, so we could access vault
+        echo "Creating a port-forward from $PORT_TO_FORWARD to 8200 for Vault"
+        kubectl port-forward -n $KUBE_NAMESPACE service/vault "$PORT_TO_FORWARD":8200 &
+        while ! nc -z localhost "$PORT_TO_FORWARD"; do echo "Waiting for the port-forward from $PORT_TO_FORWARD to 8200 to take effect"; sleep 1; done
+}

--- a/hack/tools/vault_utils.sh
+++ b/hack/tools/vault_utils.sh
@@ -5,93 +5,59 @@
 : ${PORT_TO_FORWARD:=8200}
 
 # $1 role name
-# $2 Vault token
-# $3 policy name
-# $4 path to auth method
-# $5 vault address
-# $6 bound_service_account_namespaces
+# $2 policy name
+# $3 path to auth method
+# $4 bound_service_account_namespaces
 create_role() {
         # Configure a role for the secret-provider
         echo "creating role $1 in k8s auth"
-        curl \
-        --header "X-Vault-Token: $2" \
-        --request POST \
-        --data '{"bound_service_account_names": "*", "bound_service_account_namespaces": "'$6'", "policies": "'$1'", "ttl": "24h"}' \
-        "$5"/v1/auth/$4/role/"$1"
+        bin/vault write auth/"$3"/role/"$1" \
+        bound_service_account_names="*" \
+        bound_service_account_namespaces="$4" \
+        policies=$1 \
+        ttl=24h
+
 }
 
-# $1 - the path of the secret
-# $2 - the secret, as json
-# $3 - vault-token
-# $4 - vault address
-push_secret() {
-        curl \
-        -H "X-Vault-Token: $3" \
-        -H "Content-Type: application/json" \
-        -X POST \
-        -d "$2" \
-        "$4"/v1/"$1"
-}
-
+# $1 kv engine path
 enable_kv() {
         # Enable kv engine to write secrets to vault
         echo "enabling kv engine for endpoint: $1"
-
-        # Enable the secret endpoint
-        curl \
-        --header "X-Vault-Token: $2" \
-        --request POST \
-        --data '{"type": "kv", "options": {"version": "1"} }' \
-        "$3"/v1/sys/mounts/"$1"
-
-        # Equivalent using the CLI:
-        # vault secrets enable -path=$2 -version=1 kv
+        bin/vault secrets enable -path=$1 -version=1 kv || true
 }
 
-# $1 - vault-token
-# $2 - cluster path in vault
-# $3 - vault sa secret name
-# $4 - vault sa secret namespace
-# $5 - vault address
-# $6 - kube host
+# $1 - auth path name in bin/vault
+# $2 - bin/vault sa secret name
+# $3 - bin/vault sa secret namespace
+# $4 - kube host
 enable_k8s_auth() {
         # Enable k8s service account token auth
         echo "enabling k8s auth $1 $2 $3 $4"
-        curl \
-        --header "X-Vault-Token: $1" \
-        --request POST \
-        --data '{"type": "kubernetes"}' \
-        "$5"/v1/sys/auth/"$2"
+        bin/vault auth enable -path="$1" kubernetes || true
 
-        # Equivalent using the CLI:
-        # vault auth enable <auth path>
-
-        TOKEN_REVIEW_JWT=$(kubectl get secret $3 -n $4 -o jsonpath="{.data.token}" | base64 --decode)
-        KUBE_CA_CERT=$(jq -n --arg cert "$(kubectl get secret $3 -n $4 -o jsonpath="{.data['ca\.crt']}" | base64 --decode)" '$cert')
+        TOKEN_REVIEW_JWT=$(kubectl get secret $2 -n $3 -o jsonpath="{.data.token}" | base64 --decode)
+        mkdir -p ./tmp
+        kubectl get secret $2 -n $3 -o jsonpath="{.data['ca\.crt']}" | base64 --decode > tmp/ca.crt
 
         # Configure the k8s sa auth
         echo "configuring k8s auth"
-        curl \
-        --header "X-Vault-Token: $1" \
-        --request POST \
-        --data '{"token_reviewer_jwt":"'"$TOKEN_REVIEW_JWT"'", "kubernetes_ca_cert":'"$KUBE_CA_CERT"', "kubernetes_host":"'"$6"'"}' \
-        "$5"/v1/auth/"$2"/config
+        bin/vault write auth/"$1"/config \
+        token_reviewer_jwt="$TOKEN_REVIEW_JWT" \
+        kubernetes_host="$4" \
+        kubernetes_ca_cert=@tmp/ca.crt
+        rm -rf ./tmp
 }
 
 
 # $1 - policy name
 # $2 - path
-# $3 - vault-token
-# $4 - vault address
 create_policy() {
-        echo "creating policy $1, to access the secrets in: $2 $3 "
-        curl \
-        --header "X-Vault-Token: $3" \
-        --request PUT \
-        --data '{"policy": "path \"'$2'\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }"}' \
-        "$4"/v1/sys/policy/"$1"
-        # Equivalent using the CLI:
-        # vault policy write "$1" - <<EOF
+	echo "creating policy $1, to access the secrets in: $2"
+        bin/vault policy write "$1" - <<EOF
+        path "$2" {
+        capabilities = ["create", "read", "update", "delete", "list"]
+        }
+EOF
 }
 
 # Do port-forwarding


### PR DESCRIPTION
I appreciate feedback regarding  this implementation of https://github.com/IBM/the-mesh-for-data/issues/335.
It uses a new configure_vault_kind.sh script under hack/tools/ directory which intended to be ran after the control-plane (including Vault) was initiated (using hack/install.sh for example). I took most of the script functionality from  secret-provider Vault utility functions.
The script enables K8S auth method in a new path called kind for a single cluster setup and an additional  K8S auth method in a new path called control for a multi-cluster setup thus it does not interfere with the current secret-provider implementation (which enables K8S auth method in a path called kubernetes)
An alternative approach would be to have the m4d-controller configure Vault for the clusters using parameters from config-maps.

Note: this PR does not include the documentation changes required by this issue. If this approach is OK then I will do that in a separate follow up patch. 
