### PR TITLE
replaced redacted with redact in action names

### DIFF
--- a/connectors/opa/lib/opa_reader.go
+++ b/connectors/opa/lib/opa_reader.go
@@ -20,7 +20,7 @@ func NewOpaReader(opasrvurl string) *OpaReader {
 	return &OpaReader{opaServerURL: opasrvurl}
 }
 
-func (r *OpaReader) GetOPADecisions(in *pb.ApplicationContext, catalogReader *CatalogReader, policyToBeEvaluated string) (*pb.PoliciesDecisions,  error) {
+func (r *OpaReader) GetOPADecisions(in *pb.ApplicationContext, catalogReader *CatalogReader, policyToBeEvaluated string) (*pb.PoliciesDecisions, error) {
 	datasetsMetadata, err := catalogReader.GetDatasetsMetadataFromCatalog(in)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func buildNewEnfrocementAction(transformAction interface{}) (*pb.EnforcementActi
 				}
 			case "redact column":
 				if columnName, ok := extractArgument(action["arguments"], "column_name"); ok {
-					newEnforcementAction := &pb.EnforcementAction{Name: "redacted", Id: "redacted-ID",
+					newEnforcementAction := &pb.EnforcementAction{Name: "redact", Id: "redact-ID",
 						Level: pb.EnforcementAction_COLUMN, Args: map[string]string{"column_name": columnName}}
 					return newEnforcementAction, newUsedPolicy, true
 				}

--- a/pkg/policy-compiler/testutil/helper.go
+++ b/pkg/policy-compiler/testutil/helper.go
@@ -79,7 +79,7 @@ func ConstructEncryptColumn(colName string) *pb.EnforcementAction {
 }
 
 func ConstructRedactColumn(colName string) *pb.EnforcementAction {
-	return &pb.EnforcementAction{Name: "redacted", Id: "redacted-ID",
+	return &pb.EnforcementAction{Name: "redact", Id: "redact-ID",
 		Level: pb.EnforcementAction_COLUMN, Args: map[string]string{"column_name": colName}}
 }
 


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@il.ibm.com>

Replacing "redacted" with "redact" in enforcement action name/id to preserve consistency.