### PR TITLE
style: organize imports

### DIFF
--- a/manager/apis/app/v1alpha1/blueprint_types_test.go
+++ b/manager/apis/app/v1alpha1/blueprint_types_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"context"
+
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -4,19 +4,21 @@
 package v1alpha1
 
 import (
-	"github.com/stretchr/testify/assert"
-	kv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestValidBatchTransfer(t *testing.T) {
 	t.Parallel()
 	batchTransfer := BatchTransfer{
-		TypeMeta:   v1.TypeMeta{},
-		ObjectMeta: v1.ObjectMeta{},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
 		Spec: BatchTransferSpec{
 			Source: DataStore{
 				Database: &Database{

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	kv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -66,8 +65,8 @@ func TestValidBatchTransfer(t *testing.T) {
 func TestValidBatchTransferKafka(t *testing.T) {
 	t.Parallel()
 	batchTransfer := BatchTransfer{
-		TypeMeta:   v1.TypeMeta{},
-		ObjectMeta: v1.ObjectMeta{},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
 		Spec: BatchTransferSpec{
 			Source: DataStore{
 				Database: &Database{
@@ -187,8 +186,8 @@ func TestDefaultingS3Bucket(t *testing.T) {
 	_ = os.Setenv("SECRET_PROVIDER_ROLE", "demo")
 
 	batchTransfer := BatchTransfer{
-		TypeMeta:   v1.TypeMeta{},
-		ObjectMeta: v1.ObjectMeta{},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
 		Spec: BatchTransferSpec{
 			Source: DataStore{
 				Database: &Database{
@@ -231,7 +230,7 @@ func TestDefaultingS3Bucket(t *testing.T) {
 
 	batchTransfer.Default()
 
-	assert.Equal(t, kv1.PullAlways, batchTransfer.Spec.ImagePullPolicy)
+	assert.Equal(t, corev1.PullAlways, batchTransfer.Spec.ImagePullPolicy)
 	assert.Equal(t, "mover-test:latest", batchTransfer.Spec.Image)
 	assert.Equal(t, "mysecrets:123", batchTransfer.Spec.SecretProviderURL)
 	assert.Equal(t, "demo", batchTransfer.Spec.SecretProviderRole)

--- a/manager/controllers/app/plotter_controller_unit_test.go
+++ b/manager/controllers/app/plotter_controller_unit_test.go
@@ -5,10 +5,12 @@ package app
 
 import (
 	"context"
+	"io/ioutil"
+	"testing"
+
 	app "github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster/dummy"
 	"github.com/onsi/gomega"
-	"io/ioutil"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -18,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 // TestBatchTransferController runs BatchTransferReconciler.Reconcile() against a

--- a/manager/controllers/motion/batchtransfer_controller.go
+++ b/manager/controllers/motion/batchtransfer_controller.go
@@ -6,10 +6,11 @@ package motion
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	kbatch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
@@ -128,7 +129,7 @@ func (reconciler *BatchTransferReconciler) Reconcile(req ctrl.Request) (ctrl.Res
 	}
 
 	// Make sure that the secret exists
-	existingSecret := &v1.Secret{}
+	existingSecret := &corev1.Secret{}
 	if err := reconciler.Get(ctx, batchTransfer.ObjectKey(), existingSecret); err != nil {
 		if !kerrors.IsNotFound(err) {
 			log.Error(err, "could not fetch Secret for batchTransfer %s", batchTransfer.ObjectKey())
@@ -177,7 +178,7 @@ func (reconciler *BatchTransferReconciler) SetupWithManager(mgr ctrl.Manager) er
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&motionv1.BatchTransfer{}).
 		Owns(&kbatch.Job{}).
-		Owns(&v1.Pod{}).
+		Owns(&corev1.Pod{}).
 		Complete(reconciler)
 }
 

--- a/manager/controllers/motion/batchtransfer_controller_cronjobs.go
+++ b/manager/controllers/motion/batchtransfer_controller_cronjobs.go
@@ -5,6 +5,7 @@ package motion
 
 import (
 	"context"
+
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/manager/controllers/motion/batchtransfer_controller_jobs.go
+++ b/manager/controllers/motion/batchtransfer_controller_jobs.go
@@ -6,14 +6,15 @@ package motion
 import (
 	"context"
 	"encoding/json"
+	"path"
+	"sort"
+
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	kbatch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
 )
 
 // Returns the volume configuration for a BatchTransfer.

--- a/manager/controllers/motion/batchtransfer_controller_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_test.go
@@ -6,9 +6,10 @@ package motion
 import (
 	"context"
 	"io/ioutil"
+	"time"
+
 	kbatch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"time"
 
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	. "github.com/onsi/ginkgo"

--- a/manager/controllers/motion/batchtransfer_controller_unit_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_unit_test.go
@@ -5,14 +5,15 @@ package motion
 
 import (
 	"context"
+	"testing"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 
 	kbatch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/manager/controllers/motion/batchtransfer_controller_unit_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_unit_test.go
@@ -13,7 +13,7 @@ import (
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 
 	kbatch "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -110,7 +110,7 @@ func TestBatchTransferController(t *testing.T) {
 	}
 
 	// Check if the secret has been created
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err = cl.Get(context.TODO(), req.NamespacedName, secret)
 	if err != nil {
 		t.Fatalf("get secret: (%v)", err)

--- a/manager/controllers/motion/motion_controllers.go
+++ b/manager/controllers/motion/motion_controllers.go
@@ -4,8 +4,9 @@
 package motion
 
 import (
-	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	"os"
+
+	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )

--- a/manager/controllers/motion/streamtransfer_controller.go
+++ b/manager/controllers/motion/streamtransfer_controller.go
@@ -6,6 +6,7 @@ package motion
 import (
 	"context"
 	"fmt"
+
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/manager/controllers/motion/streamtransfer_controller_test.go
+++ b/manager/controllers/motion/streamtransfer_controller_test.go
@@ -6,8 +6,9 @@ package motion
 import (
 	"context"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	. "github.com/onsi/ginkgo"

--- a/manager/controllers/motion/streamtransfer_controller_test.go
+++ b/manager/controllers/motion/streamtransfer_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -68,11 +68,11 @@ var _ = Describe("StreamTransfer Controller", func() {
 
 			By("Expecting Secret to be created")
 			Eventually(func() error {
-				secret := &v1.Secret{}
+				secret := &corev1.Secret{}
 				return k8sClient.Get(context.Background(), key, secret)
 			}, timeout, interval).Should(Succeed())
 
-			pvc := &v1.PersistentVolumeClaim{}
+			pvc := &corev1.PersistentVolumeClaim{}
 			By("Expecting PVC to be created")
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), key, pvc)
@@ -118,7 +118,7 @@ var _ = Describe("StreamTransfer Controller", func() {
 				return k8sClient.Delete(context.Background(), f)
 			}, timeout, interval).Should(Succeed())
 
-			finalizerPod := &v1.Pod{}
+			finalizerPod := &corev1.Pod{}
 			By("Expect finalizer pod to be started")
 			Eventually(func() error {
 
@@ -128,7 +128,7 @@ var _ = Describe("StreamTransfer Controller", func() {
 
 			if !noSimulatedProgress {
 				// Simulate a succeeded finalizer
-				finalizerPod.Status.Phase = v1.PodSucceeded
+				finalizerPod.Status.Phase = corev1.PodSucceeded
 				Expect(k8sClient.Status().Update(context.Background(), finalizerPod)).Should(Succeed())
 			}
 

--- a/manager/controllers/motion/streamtransfer_deployment.go
+++ b/manager/controllers/motion/streamtransfer_deployment.go
@@ -5,13 +5,15 @@ package motion
 
 import (
 	"context"
+	"path"
+
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path"
 
 	"encoding/json"
+
 	apps "k8s.io/api/apps/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )

--- a/manager/controllers/motion/suite_test.go
+++ b/manager/controllers/motion/suite_test.go
@@ -4,13 +4,14 @@
 package motion
 
 import (
-	"github.com/onsi/gomega/gexec"
 	"os"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	"testing"
 	"time"
+
+	"github.com/onsi/gomega/gexec"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
 	. "github.com/onsi/ginkgo"

--- a/pkg/multicluster/dummy/dummy_manager.go
+++ b/pkg/multicluster/dummy/dummy_manager.go
@@ -2,6 +2,7 @@ package dummy
 
 import (
 	"errors"
+
 	"github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
 )

--- a/pkg/multicluster/dummy/dummy_manager_test.go
+++ b/pkg/multicluster/dummy/dummy_manager_test.go
@@ -2,11 +2,12 @@ package dummy
 
 import (
 	"errors"
+	"testing"
+
 	app "github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 var _ multicluster.ClusterManager = &ClusterManager{}

--- a/pkg/multicluster/local/local_cluster_manager_test.go
+++ b/pkg/multicluster/local/local_cluster_manager_test.go
@@ -1,14 +1,15 @@
 package local
 
 import (
+	"testing"
+
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster"
 	"github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 var _ multicluster.ClusterManager = &ClusterManager{}
@@ -17,7 +18,7 @@ func TestLocalClusterManager(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	s := scheme.Scheme
 	objs := []runtime.Object{
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster-metadata",
 				Namespace: "m4d-system",

--- a/pkg/multicluster/multi_cluster_manager_test.go
+++ b/pkg/multicluster/multi_cluster_manager_test.go
@@ -1,12 +1,14 @@
 package multicluster
 
 import (
+	"testing"
+
 	"github.com/onsi/gomega"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 )
 
 func TestDecodeJsonToRuntimeObject(t *testing.T) {
@@ -54,8 +56,8 @@ func TestDecodeJsonToRuntimeObject(t *testing.T) {
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: &replicaNumber,
-			Template: v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
 					Containers: []v1.Container{
 						{
 							Name:  "container",

--- a/pkg/multicluster/multi_cluster_manager_test.go
+++ b/pkg/multicluster/multi_cluster_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/onsi/gomega"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -58,7 +57,7 @@ func TestDecodeJsonToRuntimeObject(t *testing.T) {
 			Replicas: &replicaNumber,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []v1.Container{
+					Containers: []corev1.Container{
 						{
 							Name:  "container",
 							Image: "image",

--- a/pkg/multicluster/razee/razee.go
+++ b/pkg/multicluster/razee/razee.go
@@ -2,9 +2,10 @@ package razee
 
 import (
 	"context"
-	"github.com/machinebox/graphql"
 	"net/http"
 	"time"
+
+	"github.com/machinebox/graphql"
 )
 
 //nolint:golint,unused

--- a/pkg/multicluster/razee/razee_cluster_manager.go
+++ b/pkg/multicluster/razee/razee_cluster_manager.go
@@ -3,6 +3,10 @@ package razee
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/IBM/go-sdk-core/core"
 	"github.com/IBM/satcon-client-go/client"
 	"github.com/ghodss/yaml"
@@ -12,10 +16,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"strconv"
-	"strings"
 )
 
 const (

--- a/samples/gui/server/datauser/k8sclient.go
+++ b/samples/gui/server/datauser/k8sclient.go
@@ -5,6 +5,7 @@ package datauser
 
 import (
 	"context"
+
 	dm "github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Problem: when working with an IDE that is configured with auto import or imports formatter (goimports, goreturns or gopls) the imports style changes although it's unrelated to the PR. This now becomes an issue because gopls is enabled by default in VSCode.
To avoid inconsistencies in imports I ran goimports and excluded non-generated files (all of the tools above format it the same). @froesef it seems like all of the files that didn't follow this style are owned by you. We don't have a code style guide yet but would be nice to be aligned as much as possible until we do.