### PR TITLE
rbac: removed kubebuilder:rbac markers

### DIFF
--- a/manager/Makefile
+++ b/manager/Makefile
@@ -41,7 +41,7 @@ generate: $(TOOLBIN)/controller-gen
 # Generate code
 .PHONY: manifests
 manifests: $(TOOLBIN)/controller-gen
-	$(TOOLBIN)/controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(TOOLBIN)/controller-gen $(CRD_OPTIONS) webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Install CRDs into a cluster
 .PHONY: install

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -38,9 +38,6 @@ type BlueprintReconciler struct {
 	Helmer helm.Interface
 }
 
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=blueprints,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=blueprints/status,verbs=get;update;patch
-
 // Reconcile receives a Blueprint CRD
 //nolint:dupl
 func (r *BlueprintReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -47,15 +47,6 @@ type M4DApplicationReconciler struct {
 	Provision         storage.ProvisionInterface
 }
 
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=m4dapplications,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=m4dapplications/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=blueprints,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=plotters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=m4dmodules,verbs=get;list;watch
-
-// +kubebuilder:rbac:groups=*,resources=*,verbs=*
-
 // Reconcile reconciles M4DApplication CRD
 // It receives M4DApplication CRD and selects the appropriate modules that will run
 // The outcome is either a single Blueprint running on the same cluster or a Plotter containing multiple Blueprints that may run on different clusters

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -36,9 +36,6 @@ type PlotterReconciler struct {
 // BlueprintNamespace defines a namespace where blueprints and associated resources will be allocated
 const BlueprintNamespace = "m4d-blueprints"
 
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=plotters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=plotters/status,verbs=get;update;patch
-
 // Reconcile receives a Plotter CRD
 //nolint:dupl
 func (r *PlotterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/manager/controllers/app/storage.go
+++ b/manager/controllers/app/storage.go
@@ -16,9 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// +kubebuilder:rbac:groups=app.m4d.ibm.com,resources=m4dstorageaccounts,verbs=get;list;watch;update;
-// +kubebuilder:rbac:groups=com.ie.ibm.hpsys,resources=datasets,verbs=get;list;watch;create;update;patch;delete
-
 func includesGeography(array []string, element string) bool {
 	for _, geo := range array {
 		if geo == element {

--- a/manager/controllers/motion/batchtransfer_controller.go
+++ b/manager/controllers/motion/batchtransfer_controller.go
@@ -34,16 +34,6 @@ type BatchTransferReconciler struct {
 	Reconciler
 }
 
-// annotation that allow this controller to access both BatchTransfers as well as Jobs and their status.
-// +kubebuilder:rbac:groups=motion.m4d.ibm.com,resources=batchtransfers;batchtransfers/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=motion.m4d.ibm.com,resources=batchtransfers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=batch,resources=jobs;jobs/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=pods;pods/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
-// +kubebuilder:rbac:groups="",resources=events;secrets;secrets/finalizers,verbs=create;delete;get;list;patch;update;watch
-
-// the empty line above is really important, otherwise make manifests won't build the rbac/role.yaml
-
 // This is the main entry point of the controller. It reconciles BatchTransfer objects.
 // The batch transfer is implemented as a K8s Job or CronJob.
 // Reconciliation happens with the following steps:

--- a/manager/controllers/motion/streamtransfer_controller.go
+++ b/manager/controllers/motion/streamtransfer_controller.go
@@ -21,13 +21,6 @@ type StreamTransferReconciler struct {
 	Reconciler
 }
 
-// +kubebuilder:rbac:groups=motion.m4d.ibm.com,resources=streamtransfers;streamtransfers/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=motion.m4d.ibm.com,resources=streamtransfers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments;deployments/finalizers;deployments/status,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=pods;pods/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims;persistentvolumeclaims/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=events;secrets;secrets/finalizers,verbs=create;delete;get;list;patch;update;watch
-
 // Reconcile StreamTransfers
 // A first version of this StreamTransfer is based on K8s Deployment objects.
 // These manage pod failures themselves and restart them in case of failure.


### PR DESCRIPTION
Part of #348 

Source of truth is the RBAC files in config and once the move to Helm is complete then it charts. Does not include a fix for #304.