### PR TITLE
Default values of implicit copy charts should be {} instead of empty …

### DIFF
--- a/modules/m4d-implicit-copy-batch/values.yaml
+++ b/modules/m4d-implicit-copy-batch/values.yaml
@@ -20,21 +20,21 @@ noFinalizer: "false"
 copy:
   source:
     connection:
-      s3:
-        endpoint: ""
-        bucket: ""
-        object_key: ""
-    format: ""
-    credentialLocation: ""
+      s3: {}
+#        endpoint: ""
+#        bucket: ""
+#        object_key: ""
+#    format: ""
+#    credentialLocation: ""
 
   # copies to destination
   destination:
     connection:
-      s3:
-        endpoint: ""
-        bucket: ""
-        object_key: ""
-    format: ""
-    credentialLocation: ""
+      s3: {}
+#        endpoint: ""
+#        bucket: ""
+#        object_key: ""
+#    format: ""
+#    credentialLocation: ""
 
   transformations: []

--- a/modules/m4d-implicit-copy-stream/values.yaml
+++ b/modules/m4d-implicit-copy-stream/values.yaml
@@ -13,25 +13,25 @@ copy:
   # copies from source
   source:
     connection:
-      kafka:
-        bootstrap_servers: ""
-        schema_registry: ""
-        topic_name: ""
-        ssl_truststore: ""
-        ssl_truststore_password: ""
-        security_protocol: ""
-        sasl_mechanism: ""
-        key_deserializer: ""
-        value_deserializer: ""
-    credentialLocation: ""
-    format: ""
+      kafka: {}
+#        bootstrap_servers: ""
+#        schema_registry: ""
+#        topic_name: ""
+#        ssl_truststore: ""
+#        ssl_truststore_password: ""
+#        security_protocol: ""
+#        sasl_mechanism: ""
+#        key_deserializer: ""
+#        value_deserializer: ""
+#    credentialLocation: ""
+#    format: ""
 
   # copies to destination
   destination:
     connection:
-      s3:
-        endpoint: ""
-        bucket: ""
-        object_key: ""
-    format: ""
-    credentialLocation: ""
+      s3: {}
+#        endpoint: ""
+#        bucket: ""
+#        object_key: ""
+#    format: ""
+#    credentialLocation: ""


### PR DESCRIPTION
…strings in the field values

Signed-off-by: Florian Froese <ffr@zurich.ibm.com>