### PR TITLE
Add configmap m4d-config to the helm chart. 

### DIFF
--- a/charts/m4d/templates/_helpers.tpl
+++ b/charts/m4d/templates/_helpers.tpl
@@ -72,3 +72,14 @@ Create the value of an image field from hub, image and tag
 {{- printf "%s/%s:%s" ( $ctx.hub | default $root.Values.global.hub ) $ctx.image ( $ctx.tag | default $root.Values.global.tag | default $root.Chart.AppVersion ) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Inject extra environment vars if populated
+*/}}
+{{- define "config.extraEnvironmentVars" -}}
+{{- if .Values.config.extraEnvironmentVars -}}
+{{- range $key, $value := .Values.config.extraEnvironmentVars }}
+  {{ $key | quote }} : {{ $value | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: m4d-config
+data:
+  SECRET_PROVIDER_URL: "http://secret-provider.m4d-system:5555/get-secret"
+  SECRET_PROVIDER_ROLE: "demo"
+
+  {{- with .Values.vault }}
+  VAULT_ADDRESS: {{ .internal.vault_address }}
+  VAULT_DATASET_HOME: {{ .internal.dataset_home }}
+  VAULT_USER_HOME: {{ .internal.user_home }}
+  VAULT_DATASET_MOUNT: {{ .internal.dataset_mount }}
+  VAULT_USER_MOUNT: {{ .internal.user_mount }}
+  VAULT_TTL: {{ .internal.ttl }}
+  VAULT_AUTH: "kubernetes"
+  USER_VAULT_ADDRESS: {{ .external.user_vault_address }}
+  USER_VAULT_PATH: {{ .external.user_vault_path }}
+  {{- end }}
+

--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -3,18 +3,31 @@ kind: ConfigMap
 metadata:
   name: m4d-config
 data:
+  {{- with .Values.config }}
   SECRET_PROVIDER_URL: "http://secret-provider.m4d-system:5555/get-secret"
   SECRET_PROVIDER_ROLE: "demo"
-
-  {{- with .Values.vault }}
-  VAULT_ADDRESS: {{ .internal.vault_address }}
-  VAULT_DATASET_HOME: {{ .internal.dataset_home }}
-  VAULT_USER_HOME: {{ .internal.user_home }}
-  VAULT_DATASET_MOUNT: {{ .internal.dataset_mount }}
-  VAULT_USER_MOUNT: {{ .internal.user_mount }}
-  VAULT_TTL: {{ .internal.ttl }}
-  VAULT_AUTH: "kubernetes"
-  USER_VAULT_ADDRESS: {{ .external.user_vault_address }}
-  USER_VAULT_PATH: {{ .external.user_vault_path }}
+  VAULT_ADDRESS: {{ .vault.address }}
+  VAULT_DATASET_HOME: {{ .vault.datasetHome }}
+  VAULT_DATASET_MOUNT: {{ .vault.datasetMount }}
+  VAULT_USER_HOME: {{ .vault.userHome }}
+  VAULT_USER_MOUNT: {{ .vault.userMount }}
+  VAULT_TTL: {{ .vault.ttl }}
+  USER_VAULT_ADDRESS: {{ .vault.userVaultAddress }}
+  USER_VAULT_PATH: {{ .vault.userVaultPath }}
+  MODULES_VAULT_ROLE: {{ .vault.modulesRole }}
+  CATALOG_CONNECTOR_URL: {{ .catalog.connectorUrl }}
+  CATALOG_PROVIDER_NAME: {{ .catalog.name }}
+  EGERIA_SERVER_URL: {{ .catalog.url }}
+  MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .policyManager.connectorUrl }}
+  MAIN_POLICY_MANAGER_NAME: {{ .policyManager.name }}
+  OPA_SERVER_URL: {{ .policyManager.url }}
+  {{- if .policyManager.extensionManager.enabled }}
+  USE_EXTENSIONPOLICY_MANAGER: "true"
+  EXTENSIONS_POLICY_MANAGER_CONNECTOR_URL: {{ .policyManager.extensionManager.connectorUrl }}
+  EXTENSIONS_POLICY_MANAGER_NAME: {{ .policyManager.extensionManager.name }}
+  {{- else }}
+  USE_EXTENSIONPOLICY_MANAGER: "false"
   {{- end }}
-
+  CONNECTION_TIMEOUT: "{{ .connectionTimeout }}"
+  {{- end }}
+  {{- include "config.extraEnvironmentVars" . }}

--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -22,12 +22,10 @@ data:
   MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .policyManager.connectorUrl }}
   MAIN_POLICY_MANAGER_NAME: {{ .policyManager.name }}
   OPA_SERVER_URL: {{ .policyManager.url }}
+  USE_EXTENSIONPOLICY_MANAGER: "{{ .policyManager.extensionManager.enabled }}"
   {{- if .policyManager.extensionManager.enabled }}
-  USE_EXTENSIONPOLICY_MANAGER: "true"
   EXTENSIONS_POLICY_MANAGER_CONNECTOR_URL: {{ .policyManager.extensionManager.connectorUrl }}
   EXTENSIONS_POLICY_MANAGER_NAME: {{ .policyManager.extensionManager.name }}
-  {{- else }}
-  USE_EXTENSIONPOLICY_MANAGER: "false"
   {{- end }}
   CONNECTION_TIMEOUT: "{{ .connectionTimeout }}"
   {{- end }}

--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -6,6 +6,7 @@ data:
   {{- with .Values.config }}
   SECRET_PROVIDER_URL: "http://secret-provider.m4d-system:5555/get-secret"
   SECRET_PROVIDER_ROLE: "demo"
+  VAULT_AUTH: "kubernetes"
   VAULT_ADDRESS: {{ .vault.address }}
   VAULT_DATASET_HOME: {{ .vault.datasetHome }}
   VAULT_DATASET_MOUNT: {{ .vault.datasetMount }}

--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -14,7 +14,7 @@ data:
   VAULT_TTL: {{ .vault.ttl }}
   USER_VAULT_ADDRESS: {{ .vault.userVaultAddress }}
   USER_VAULT_PATH: {{ .vault.userVaultPath }}
-  MODULES_VAULT_ROLE: {{ .vault.modulesRole }}
+  VAULT_MODULES_ROLE: {{ .vault.modulesRole }}
   CATALOG_CONNECTOR_URL: {{ .catalog.connectorUrl }}
   CATALOG_PROVIDER_NAME: {{ .catalog.name }}
   EGERIA_SERVER_URL: {{ .catalog.url }}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -189,3 +189,36 @@ clusterScoped: true
 # Set to true to enable socat in the manager pod to forward
 # traffic from a localhost registry. Used only for development.
 integrationTests: false
+
+# Vault related values set in m4d-config ConfigMap.
+vault:
+
+  # Internal Vault server variables.
+  internal:
+    # Set to the Vault address.
+    vault_address: "http://vault.m4d-system:8200/"
+
+    # Set to the path where credentials of dataset accessed by the m4d are stored.
+    dataset_home: "m4d/dataset-creds/"
+
+    # Set to the path where the user credentials for external systems are stored.
+    user_home: "m4d/user-creds/"
+
+    # Set to the secret engine mount path for the dataset credentials.
+    dataset_mount: "v1/sys/mounts/m4d/dataset-creds"
+
+    # Set to the secret engine mount path for the user credentials for the external systems.
+    user_mount: "v1/sys/mounts/m4d/user-creds"
+
+    # Set to the amount of time the authorization issued by vault is valid.
+    ttl: "24h"
+
+  # External Vault variables: This relates to local Vault that acts as "user vault" which is
+  # user deployed vault that stores there credentials to data source for data assets.
+  external:
+    # Set to the Vault address that stores the credentials to data source for data assets.
+    user_vault_address: "http://vault:8200/"
+
+    # Set to the path where credentials to data source for data assets are stored.
+    user_vault_path: "external"
+

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -190,35 +190,55 @@ clusterScoped: true
 # traffic from a localhost registry. Used only for development.
 integrationTests: false
 
-# Vault related values set in m4d-config ConfigMap.
-vault:
-
-  # Internal Vault server variables.
-  internal:
+# Values set in m4d-config ConfigMap.
+config:
+  # Vault related values set in m4d-config ConfigMap.
+  vault:
     # Set to the Vault address.
-    vault_address: "http://vault.m4d-system:8200/"
-
+    address: "http://vault.m4d-system:8200/"
     # Set to the path where credentials of dataset accessed by the m4d are stored.
-    dataset_home: "m4d/dataset-creds/"
-
-    # Set to the path where the user credentials for external systems are stored.
-    user_home: "m4d/user-creds/"
-
-    # Set to the secret engine mount path for the dataset credentials.
-    dataset_mount: "v1/sys/mounts/m4d/dataset-creds"
-
-    # Set to the secret engine mount path for the user credentials for the external systems.
-    user_mount: "v1/sys/mounts/m4d/user-creds"
-
-    # Set to the amount of time the authorization issued by vault is valid.
+    datasetHome: "m4d/dataset-creds/"
+    # Set to the dataset credentials secret engine mount path.
+    datasetMount: "v1/sys/mounts/m4d/dataset-creds"
+    # Set to the path where user credentials are stored.
+    userHome: "m4d/user-creds/"
+    # Set to the user credentials secret engine mount path.
+    userMount: "v1/sys/mounts/m4d/user-creds"
+    # Set to the amount of time the authorization issued by Vault is valid.
     ttl: "24h"
-
-  # External Vault variables: This relates to local Vault that acts as "user vault" which is
-  # user deployed vault that stores there credentials to data source for data assets.
-  external:
     # Set to the Vault address that stores the credentials to data source for data assets.
-    user_vault_address: "http://vault:8200/"
-
+    userVaultAddress: "http://vault:8200/"
     # Set to the path where credentials to data source for data assets are stored.
-    user_vault_path: "external"
+    userVaultPath: "external"
+    # Set to the name of the role that modules use to access dataset credentials.
+    modulesRole: "module"
 
+  catalog:
+    # Set to the catalog URL.
+    url: "https://lab-core.egeria-catalog:9443"
+    # Set to the catalog connector URL.
+    connectorUrl: "egr-connector:50084"
+    # Set to the catalog provider name.
+    name: "EGERIA"
+
+  policyManager:
+    # Set to policyManager URL.
+    url: "opa:8181"
+    # Set to the policy manager connector URL.
+    connectorUrl: "opa-connector:50082"
+    # Set to the policy manager connector name.
+    name: "OPA"
+    # Set to true if an extension policy manager is used.
+    extensionManager:
+      enabled: false
+      # Set to extension policy manager connector URL.
+      # connectorUrl: ""
+      # Set to extension policy manager name.
+      # name: ""
+
+  # Set to grpc connection timeout.
+  connectionTimeout: "120"
+
+  # extraEnvironmentVars is a list of extra environment variables to set.
+  extraEnvironmentVars:
+    OPA_POLICY_TO_BE_EVALUATED: "sample_policies"


### PR DESCRIPTION
This patch adds the config-map m4d-config to the helm chart as part of https://github.com/IBM/the-mesh-for-data/issues/348.
It contains mostly the vault related values as a starting point.
The hard-coded values are intentional and are set for variables that expected to be removed such as the secret-provider.
I use internal and external terms for vault variables as is in the implementation today but that might also be changed due to changes in the code.
