### PR TITLE
ci: publish charts workflow

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -1,0 +1,41 @@
+name: Update Charts
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Update Charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Checkout charts repository
+        uses: actions/checkout@v2
+        with:
+          repository: mesh-for-data/charts
+          path: charts-repo
+      - run: |
+          rm -rf charts-repo/charts/m4d-crd
+          rm -rf charts-repo/charts/m4d
+          cp -r main/charts/m4d-crd charts-repo/charts
+          cp -r main/charts/m4d charts-repo/charts
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CHARTS_APP_ID }}
+          private_key: ${{ secrets.CHARTS_APP_PRIVATE_KEY }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          path: charts-repo
+          signoff: true
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'Update charts to new release'
+          commit-message: Update charts
+          committer: GitHub <noreply@github.com>
+          delete-branch: true


### PR DESCRIPTION
Added a workflow to create a PR to update m4d charts on tag creation.

- Triggered on a new tag
- Creates a PR to https://github.com/mesh-for-data/charts
- Requires https://github.com/mesh-for-data/charts/pull/1 and https://github.com/mesh-for-data/charts/pull/2 to be reviewed and merged
- Secrets CHARTS_APP_ID and CHARTS_APP_PRIVATE_KEY already added to all of our repositories and to the mesh-for-data organization
- Was tested against temporary repositories

Fix #399
