### PR TITLE
Egeria default server url config changes

### DIFF
--- a/manager/config/prod/deployment_configmap.yaml
+++ b/manager/config/prod/deployment_configmap.yaml
@@ -38,7 +38,7 @@ data:
 
   #external services
   OPA_SERVER_URL: "opa:8181"
-  EGERIA_SERVER_URL: "https://lab-core.egeria-catalog:9443"
+  EGERIA_SERVER_URL: "https://egeria-platform.egeria-catalog:9443"
 
   #external vault  variables
   USER_VAULT_ADDRESS: "http://vault:8200/"


### PR DESCRIPTION
This PR changes the default value of egeria server url to https://egeria-platform.egeria-catalog:9443. This is a follow up to the changes done in the PR 394 (https://github.com/IBM/the-mesh-for-data/pull/394). 
Signed-off-by: rohithdv <rovallam@in.ibm.com>