### PR TITLE
older egeria installation cleanup

### DIFF
--- a/connectors/egeria/egeria-service-deployment/deployment.sh
+++ b/connectors/egeria/egeria-service-deployment/deployment.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# Copyright 2020 IBM Corp.
-# SPDX-License-Identifier: Apache-2.0
-
-oc adm policy add-scc-to-user privileged -z default 
-helm install lab odpi-egeria-lab -f lab.yaml

--- a/connectors/egeria/egeria-service-deployment/lab.yaml
+++ b/connectors/egeria/egeria-service-deployment/lab.yaml
@@ -1,9 +1,0 @@
-service:
-    type: ClusterIP
-    nodeport:
-      jupyter: 0
-      core: 0
-      datalake: 0
-      dev: 0
-      factory: 0
-      ui: 0


### PR DESCRIPTION
This PR removes folders which were relevant to older egeria installation procedure. This is a follow up to the changes done in the PR 394 (https://github.com/IBM/the-mesh-for-data/pull/394). 

Signed-off-by: rohithdv <rovallam@in.ibm.com>