### PR TITLE
Tidy up test targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
   verify:
     name: Verify
     runs-on: ubuntu-latest
-    env:
-      DOCKER_HOSTNAME: "localhost:5000"
-      DOCKER_NAMESPACE: m4d-system
     steps:
     - name: Install Go
       uses: actions/setup-go@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,6 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
-    env:
-      DOCKER_HOSTNAME: "localhost:5000"
-      DOCKER_NAMESPACE: m4d-system
     steps:
     - name: Set up JDK
       uses: actions/setup-java@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
       - master
 
 env:
-  DOCKER_HOSTNAME: ghcr.io
-  DOCKER_USERNAME: the-mesh-for-data
   GO_VERSION: 1.13
   JAVA_VERSION: 11
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ run-integration-tests:
 	$(MAKE) -C manager deploy_it
 	$(MAKE) -C manager wait_for_manager
 	$(MAKE) helm
+	$(MAKE) -C pkg/helm test
 	$(MAKE) -C manager run-integration-tests
 
 .PHONY: run-deploy-tests

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,8 @@ build:
 
 .PHONY: test
 test:
-	$(MAKE) -C connectors test
-	$(MAKE) -C pkg test
-	$(MAKE) -C manager test
+	go test -v ./...
+	# The tests for connectors/egeria are dropped because there are none
 
 .PHONY: run-integration-tests
 run-integration-tests: export DOCKER_HOSTNAME?=localhost:5000

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ build:
 
 .PHONY: test
 test:
-	$(MAKE) -C pkg/policy-compiler test
+	$(MAKE) -C connectors test
+	$(MAKE) -C pkg test
 	$(MAKE) -C manager test
 
 .PHONY: run-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 
 .PHONY: test
 test:
+	$(MAKE) -C manager pre-test
 	go test -v ./...
 	# The tests for connectors/egeria are dropped because there are none
 

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -15,6 +15,8 @@ include $(ROOT_DIR)/hack/make-rules/verify.mk
 config/default/kustomization.yaml: config/default/kustomization.yaml.in
 	cp $< $@
 
+pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
+
 # Run tests
 test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
 	go test ./... -coverprofile cover.out

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -18,7 +18,7 @@ config/default/kustomization.yaml: config/default/kustomization.yaml.in
 pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
 
 # Run tests
-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
+test: pre-test
 	go test ./... -coverprofile cover.out
 
 # Build manager binary

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,0 +1,6 @@
+ROOT_DIR := ../
+include $(ROOT_DIR)/Makefile.env
+
+.PHONY: test
+test:
+	go test -v ./...

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,7 +1,0 @@
-ROOT_DIR := ../
-include $(ROOT_DIR)/Makefile.env
-
-.PHONY: test
-test:
-	env
-	go test -v ./...

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -3,4 +3,5 @@ include $(ROOT_DIR)/Makefile.env
 
 .PHONY: test
 test:
+	env
 	go test -v ./...

--- a/pkg/helm/Makefile
+++ b/pkg/helm/Makefile
@@ -1,6 +1,5 @@
 ROOT_DIR := ../..
 include $(ROOT_DIR)/Makefile.env
-include $(ROOT_DIR)/hack/make-rules/docker.mk
 
 SOURCE := \
 	helm.go \

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -79,6 +79,11 @@ func TestHelmCache(t *testing.T) {
 }
 
 func TestHelmRegistry(t *testing.T) {
+	// Test should only run as integration test if registry is available
+	if host, isSet := os.LookupEnv("DOCKER_HOSTNAME"); !isSet || host != "localhost:5000" {
+		t.Skip("No integration environment found. Skipping test...")
+	}
+
 	var err error
 	origChart := buildTestChart()
 
@@ -109,6 +114,10 @@ func TestHelmRegistry(t *testing.T) {
 }
 
 func TestHelmRelease(t *testing.T) {
+	// Test should only run as integration test if registry is available
+	if host, isSet := os.LookupEnv("DOCKER_HOSTNAME"); !isSet || host != "localhost:5000" {
+		t.Skip("No integration environment found. Skipping test...")
+	}
 	var err error
 	origChart := buildTestChart()
 

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -80,7 +80,7 @@ func TestHelmCache(t *testing.T) {
 
 func TestHelmRegistry(t *testing.T) {
 	// Test should only run as integration test if registry is available
-	if host, isSet := os.LookupEnv("DOCKER_HOSTNAME"); !isSet || host != "localhost:5000" {
+	if _, isSet := os.LookupEnv("DOCKER_HOSTNAME"); !isSet {
 		t.Skip("No integration environment found. Skipping test...")
 	}
 
@@ -115,7 +115,7 @@ func TestHelmRegistry(t *testing.T) {
 
 func TestHelmRelease(t *testing.T) {
 	// Test should only run as integration test if registry is available
-	if host, isSet := os.LookupEnv("DOCKER_HOSTNAME"); !isSet || host != "localhost:5000" {
+	if _, isSet := os.LookupEnv("DOCKER_HOSTNAME"); !isSet {
 		t.Skip("No integration environment found. Skipping test...")
 	}
 	var err error

--- a/pkg/policy-compiler/Makefile
+++ b/pkg/policy-compiler/Makefile
@@ -26,14 +26,8 @@ clean:
 	$(MAKE) -C $(ROOT_DIR)/test/services/pilot/catalog-credential-mock clean
 	$(MAKE) -C $(ROOT_DIR)/test/services/pilot/policy-manager-mock clean
 
-.PHONY: policy-compiler-test
-policy-compiler-test:
-	go test ./... -coverprofile=coverage.out
-	go tool cover -func=coverage.out
-	#go tool cover -html=coverage.out
-
 .PHONY: test
-test: policy-compiler-test
-	$(MAKE) -C $(ROOT_DIR)/connectors test
-	$(MAKE) -C $(ROOT_DIR)/test/services/pilot/catalog-credential-mock test
-	$(MAKE) -C $(ROOT_DIR)/test/services/pilot/policy-manager-mock test
+test: 
+	go test ./... -coverprofile=coverage.out
+	#go tool cover -func=coverage.out
+	#go tool cover -html=coverage.out

--- a/pkg/vault/vault_dummy.go
+++ b/pkg/vault/vault_dummy.go
@@ -3,7 +3,10 @@
 
 package vault
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+)
 
 // Dummy implementation for testing
 type Dummy struct {
@@ -36,12 +39,15 @@ func (c *Dummy) Mount(path string) error {
 }
 
 func (c *Dummy) DeleteSecret(vaultPath string) error {
-	c.values[vaultPath] = ""
+	delete(c.values, vaultPath)
 	return nil
 }
 
 func (c *Dummy) GetSecret(vaultPath string) (string, error) {
-	return c.values[vaultPath], nil
+	if s, hasKey := c.values[vaultPath]; hasKey {
+		return s, nil
+	}
+	return "", errors.New("could not find key")
 }
 
 func (c *Dummy) AddSecret(path string, credentials map[string]interface{}) error {

--- a/pkg/vault/vault_interface_test.go
+++ b/pkg/vault/vault_interface_test.go
@@ -6,10 +6,11 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	utils "github.com/ibm/the-mesh-for-data/manager/controllers/utils"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	utils "github.com/ibm/the-mesh-for-data/manager/controllers/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func Log(t *testing.T, label string, err error) {
@@ -21,7 +22,7 @@ func Log(t *testing.T, label string, err error) {
 
 func TestCredentialManagerInterface(t *testing.T) {
 	var err error
-	os.Setenv("RUN_WITHOUT_VAULT", "0")
+	os.Setenv("RUN_WITHOUT_VAULT", "1")
 	t.Logf("Token = " + utils.GetVaultToken())
 	conn, err := InitConnection(utils.GetVaultAddress(), utils.GetVaultToken())
 	assert.Nil(t, err)

--- a/pkg/vault/vault_interface_test.go
+++ b/pkg/vault/vault_interface_test.go
@@ -22,6 +22,7 @@ func Log(t *testing.T, label string, err error) {
 
 func TestCredentialManagerInterface(t *testing.T) {
 	var err error
+	// TODO add environment variables to test against a real vault instance
 	os.Setenv("RUN_WITHOUT_VAULT", "1")
 	t.Logf("Token = " + utils.GetVaultToken())
 	conn, err := InitConnection(utils.GetVaultAddress(), utils.GetVaultToken())

--- a/samples/gui/server/datauser/credentialapis_test.go
+++ b/samples/gui/server/datauser/credentialapis_test.go
@@ -52,6 +52,8 @@ func deleteCredentials(t *testing.T, path string) {
 }
 
 func TestCredentialAPIs(t *testing.T) {
+	SkipOnClosedSocket("localhost:8080", t)
+
 	storeCredentials(t, cred1)
 	storeCredentials(t, cred2)
 	readCredentials(t, name)

--- a/samples/gui/server/datauser/environmentapis_test.go
+++ b/samples/gui/server/datauser/environmentapis_test.go
@@ -6,14 +6,29 @@ package datauser
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func SkipOnClosedSocket(address string, t *testing.T) {
+	timeout := time.Second
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if err != nil {
+		t.Skip("Skipping test as server is not running...")
+	}
+	if conn != nil {
+		defer conn.Close()
+	}
+}
+
 func TestEnvironmentAPIs(t *testing.T) {
 	envserverurl := "http://localhost:8080/v1/env/datauserenv"
+
+	SkipOnClosedSocket("localhost:8080", t)
 
 	sysMap := make(map[string][]string)
 	sysMap["Egeria"] = []string{"username"}

--- a/samples/gui/server/datauser/m4dapplicationapis_test.go
+++ b/samples/gui/server/datauser/m4dapplicationapis_test.go
@@ -61,6 +61,8 @@ func deleteApplication(t *testing.T, name string) {
 }
 
 func TestApplicationAPIs(t *testing.T) {
+	SkipOnClosedSocket("localhost:8080", t)
+
 	createApplication(t, dm1, dm1name)
 	createApplication(t, dm2, dm2name)
 	listApplications(t)


### PR DESCRIPTION
This PR adds the connectors and pkg directly to the `test` target of the main make file.