### PR TITLE
Document the new Vault fields sent to the modules

### DIFF
--- a/manager/apis/app/v1alpha1/m4dmodule_types.go
+++ b/manager/apis/app/v1alpha1/m4dmodule_types.go
@@ -38,14 +38,15 @@ const (
 	Read ModuleFlow = "read"
 )
 
-// CredentialManagementType indicates whether this module queries the SecretProvider by itself to get
-// credentials, or whether it assumes that the data-mesh will inject them.
+// CredentialManagementType indicates how this module gets the credentials:
+// In HashicorpVault option the module should use Hashicorp Vault client to retrieve the credentials.
+// Automatic option assumes that the data-mesh will inject the credentials to the modules.
 // +kubebuilder:validation:Enum=secret-provider;automatic
 type CredentialManagementType string
 
 const (
-	// SecretProvider is set when the module uses the Secret Provider
-	SecretProvider CredentialManagementType = "secret-provider"
+	// HashicorpVault is set when the module uses Hashicorp Vault client to get the credentials
+	HashicorpVault CredentialManagementType = "hashicorp-vault"
 
 	// Automatic is set when credential management is handled elsewhere
 	Automatic CredentialManagementType = "automatic"

--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -78,7 +78,7 @@ func createModules() {
 		Spec: apiv1alpha1.M4DModuleSpec{
 			Flows: []apiv1alpha1.ModuleFlow{apiv1alpha1.Read},
 			Capabilities: apiv1alpha1.Capability{
-				CredentialsManagedBy: apiv1alpha1.SecretProvider,
+				CredentialsManagedBy: apiv1alpha1.HashicorpVault,
 				SupportedInterfaces: []apiv1alpha1.ModuleInOut{
 					{
 						Flow:   apiv1alpha1.Read,
@@ -106,7 +106,7 @@ func createModules() {
 		Spec: apiv1alpha1.M4DModuleSpec{
 			Flows: []apiv1alpha1.ModuleFlow{apiv1alpha1.Copy},
 			Capabilities: apiv1alpha1.Capability{
-				CredentialsManagedBy: apiv1alpha1.SecretProvider,
+				CredentialsManagedBy: apiv1alpha1.HashicorpVault,
 				SupportedInterfaces: []apiv1alpha1.ModuleInOut{
 					{
 						Source: &apiv1alpha1.InterfaceDetails{Protocol: apiv1alpha1.JdbcDb2, DataFormat: apiv1alpha1.Table},

--- a/manager/testdata/e2e/module-read.yaml
+++ b/manager/testdata/e2e/module-read.yaml
@@ -16,7 +16,7 @@ spec:
   flows:
     - read
   capabilities:
-    credentials-managed-by: secret-provider
+    credentials-managed-by: hashicorp-vault
     api:
       protocol: m4d-arrow-flight
       dataformat: arrow

--- a/modules/implicit-copy-batch-module.yaml
+++ b/modules/implicit-copy-batch-module.yaml
@@ -13,7 +13,7 @@ spec:
   flows:  # one or more of copy, read, write 
   - copy  
   capabilities:
-    credentials-managed-by: secret-provider
+    credentials-managed-by: hashicorp-vault
     supportedInterfaces:
     - flow: copy
       source:

--- a/modules/implicit-copy-stream-module.yaml
+++ b/modules/implicit-copy-stream-module.yaml
@@ -13,7 +13,7 @@ spec:
   flows:
   - copy  
   capabilities:
-    credentials-managed-by: secret-provider
+    credentials-managed-by: hashicorp-vault
     supportedInterfaces:
     - flow: copy
       source: 

--- a/website/content/contribute/module/index.md
+++ b/website/content/contribute/module/index.md
@@ -21,7 +21,22 @@ The module workload is associated with a specific user workload and is deployed 
 
 ### Credential management
 
-Modules that access or write data need credentials in order to access the data store.  Rather than pass them between components, the control plane stores the credentials in an internal credential management system and passes to the module a link to the credentials.  The module must call the control plane's internal credential management interface, known as the Secret Provider, using the API described in [secret-provider/README.md](https://{{< github_base >}}/{{< github_repo >}}/blob/master/secret-provider/README.md).
+Modules that access or write data need credentials in order to access the data store. The credentials are retrieved from [HashiCorp Vault](https://www.vaultproject.io/) and the modules must use Vault client using [Vault parameters]({{< baseurl >}}/docs/reference/api/generated/app/#k8s-api-github-com-ibm-the-mesh-for-data-manager-apis-app-v1alpha1-vault) sent to them upon deployment to get the credentials from Vault server.
+
+The module should retrieve the credentials by doing two API calls to Vault server:
+First call is the [Vault Login API call](https://www.vaultproject.io/api-docs/auth/kubernetes#login). The response to this call contains a Vault token. Second call is the [Vault Read Secret API call](https://www.vaultproject.io/api/secret/kv/kv-v1#read-secret).
+
+An example for Vault Login API call which uses the Vault parameters is as follows:
+
+`
+$ curl -v --request POST <address>/<authPath> -H "Content-Type: application/json" --data '{"jwt": <module service account token>, "role": <role>}'
+`
+
+An example for Vault Read Secret API call which uses the Vault parameters is as follows:
+
+`
+$  curl --header "X-Vault-Token: ..." https://<address>/<secretPath>
+`
 
 ## Module Helm Chart
 
@@ -110,8 +125,9 @@ flows: # Indicate the data flow(s) in which the control plane should consider us
 
 ### `spec.capabilities`
 
-`capabilites.credentials-managed-by` may be either `secret-provider` or `automatic`.  Currently only `secret-provider` is supported, meaning that the module will receive a link to the data set credentials and must use the Secret Provider API to obtain the credentials. 
-TODO: Add API link
+`capabilites.credentials-managed-by` may be either `hashicorp-vault` or `automatic`.  Currently only `hashicorp-vault` is supported. hashicorp-vault` means that the module will receive the details to setup Hashicorp Vault client to obtain the credentials.
+
+
 
 `capabilites.supportedInterfaces` lists the supported data services from which the module can read data and to which it can write 
 * `flow` field can be `read`, `write` or `copy`
@@ -125,7 +141,7 @@ An example for a module that copies data from a db2 database table to an s3 buck
 
 ```yaml
 capabilities:
-    credentials-managed-by: secret-provider
+    credentials-managed-by: hashicorp-vault
     supportedInterfaces:
     - flow: copy  
       source:
@@ -140,7 +156,7 @@ An example for a module that has an API for reading data, and supports reading b
 
 ```yaml
 capabilities:
-    credentials-managed-by: secret-provider
+    credentials-managed-by: hashicorp-vault
     api:
       protocol: m4d-arrow-flight
       dataformat: arrow


### PR DESCRIPTION
Signed-off-by: Revital Sur <eres@il.ibm.com>

This PR address issue #435 
It does the following:
1) Changes the web site documentation regarding how modules should retrieve the dateset credentials.
2) Changes capabilities.credentials-managed-by field.

