### PR TITLE
Add secrets to environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,8 @@ jobs:
     env:
       DOCKER_HOSTNAME: "localhost:5000"
       DOCKER_NAMESPACE: m4d-system
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     needs: [verify, test, integration-tests]
     if: ${{ github.event_name != 'pull_request' }}
     steps:


### PR DESCRIPTION
If I understand it correct unlike in Travis secrets are not automatically added as environment variables. (They will be redacted in the logs though)