### PR TITLE
Install Vault with the version in charts directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,14 +56,13 @@ run-deploy-tests:
 cluster-prepare:
 	$(MAKE) -C third_party/cert-manager deploy
 	$(MAKE) -C third_party/registry deploy
-	$(MAKE) -C third_party/vault deploy
+	$(MAKE) -C charts vault
 	kubectl apply -f https://raw.githubusercontent.com/IBM/dataset-lifecycle-framework/master/release-tools/manifests/dlf.yaml
 
 
 .PHONY: cluster-prepare-wait
 cluster-prepare-wait:
 	$(MAKE) -C third_party/cert-manager deploy-wait
-	$(MAKE) -C third_party/vault deploy-wait
 	kubectl wait --for=condition=ready pod -n dlf --all --timeout=120s
 
 .PHONY: install

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -36,6 +36,11 @@ vault:
 	# To enable Vault to read kuberenetes secrets clusterrole and clusterrolebinding should be added.
 	kubectl apply -f ../third_party/vault/plugin-secrets-kubernetes-reader/clusterrole.yaml -n m4d-system || true
 	kubectl apply -f ../third_party/vault/plugin-secrets-kubernetes-reader/clusterrolebinding.yaml -n m4d-system || true
+	# The following should be removed after secret-provider cleanup:
+	# Secret provider configure_vault function configures Vault kubernetes auth path by binding Vault service account to ClusterRole
+	# system:auth-delegator. This is changed to use a new created service account instead of Vault service account.
+	# This way Vault auth path is configured in a similar way in all the clusters regardless if Vault deployed on the cluster.
+	kubectl apply -f ../third_party/vault/vault-rbac.yaml -n m4d-system || true
 
 .PHONY:
 vault-setup:

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -17,12 +17,8 @@ kubectl apply -f manager/config/prod/deployment_configmap.yaml
 make cluster-prepare
 kubectl create secret generic user-vault-unseal-keys --from-literal=vault-root=$(kubectl get secrets vault-unseal-keys -o jsonpath={.data.vault-root} | base64 --decode) || true
 # Install third party components
-$WITHOUT_VAULT || make -C third_party/vault deploy
 $WITHOUT_EGERIA || make -C third_party/egeria deploy
 $WITHOUT_OPA || make -C third_party/opa deploy
-
-# Waiting for the vault deployment to become ready
-make -C third_party/vault deploy-wait
 
 # Perform a port-forward to communicate with Vault
 port_forward


### PR DESCRIPTION
Signed-off-by: Revital Sur <eres@il.ibm.com>

This PR changes Vault installations to use the new Vault helm chart installation under charts directory. 
This installation starts Vault in dev mode and enables Vault vault-plugin-secrets-kubernetes-reader plugin (https://github.com/mesh-for-data/vault-plugin-secrets-kubernetes-reader). This plugin will be used for modules in m4d-blueprint namespace to retrieve dataset credentials stored as kubernetes secrets as described in issue #406.
Enabling the plugin has currently no effect on the execution flow as only after the appropriate changes in the manager and credential connector are applied (sub-issue 2 in issue #406 ) the plugin could be used.