### PR TITLE
Adding clusterScoped flag to deploy only cluster scoped resources

### DIFF
--- a/charts/m4d/templates/katalog-connector/katalog-connector-rbac.yaml
+++ b/charts/m4d/templates/katalog-connector/katalog-connector-rbac.yaml
@@ -1,5 +1,6 @@
 {{- $autoFlag := and .Values.manager.enabled .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
 {{- if include "m4d.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
+{{- if .Values.clusterScoped }}
 # Grant katalog-connector the katalog-editor Role.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,4 +14,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.katalogConnector.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/m4d/templates/katalog-connector/katalog-rbac.yaml
+++ b/charts/m4d/templates/katalog-connector/katalog-rbac.yaml
@@ -1,5 +1,6 @@
 {{- $autoFlag := and .Values.manager.enabled .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
 {{- if include "m4d.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
+{{- if .Values.clusterScoped }}
 # ClusterRole katalog-editor allows managing assets.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,4 +24,5 @@ rules:
   resources: ["assets"]
   verbs: ["get", "list", "watch"]
 ---
+{{- end }}
 {{- end }}

--- a/charts/m4d/templates/manager-auth-proxy-cr.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-cr.yaml
@@ -1,4 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if eq .Values.clusterScoped "false"}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -13,3 +14,5 @@ rules:
   - subjectaccessreviews
   verbs: ["create"]
 {{- end }}
+{{- end}}
+

--- a/charts/m4d/templates/manager-auth-proxy-cr.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-cr.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if eq .Values.clusterScoped "false"}}
+{{- if .Values.clusterScoped}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/m4d/templates/manager-auth-proxy-cr.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-cr.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped}}
+{{- if .Values.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,5 +14,5 @@ rules:
   - subjectaccessreviews
   verbs: ["create"]
 {{- end }}
-{{- end}}
+{{- end }}
 

--- a/charts/m4d/templates/manager-auth-proxy-crb.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-crb.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped}}
+{{- if .Values.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,5 +13,5 @@ subjects:
   name: {{ .Values.manager.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- end}}
+{{- end }}
 

--- a/charts/m4d/templates/manager-auth-proxy-crb.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-crb.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if eq .Values.clusterScoped "false"}}
+{{- if .Values.clusterScoped}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/m4d/templates/manager-auth-proxy-crb.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-crb.yaml
@@ -1,4 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if eq .Values.clusterScoped "false"}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,5 @@ subjects:
   name: {{ .Values.manager.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- end}}
+

--- a/charts/m4d/templates/manager-auth-proxy-service.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-service.yaml
@@ -1,4 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if eq .Values.clusterScoped "false"}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,5 @@ spec:
     control-plane: controller-manager
     {{- include "m4d.selectorLabels" . | nindent 4 }}
 {{- end }}
+{{- end}}
+

--- a/charts/m4d/templates/manager-auth-proxy-service.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-service.yaml
@@ -1,5 +1,4 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,5 +15,4 @@ spec:
     control-plane: controller-manager
     {{- include "m4d.selectorLabels" . | nindent 4 }}
 {{- end }}
-{{- end}}
 

--- a/charts/m4d/templates/manager-auth-proxy-service.yaml
+++ b/charts/m4d/templates/manager-auth-proxy-service.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if eq .Values.clusterScoped "false"}}
+{{- if .Values.clusterScoped}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/m4d/templates/manager-cr.yaml
+++ b/charts/m4d/templates/manager-cr.yaml
@@ -1,4 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if eq .Values.clusterScoped "false"}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -227,3 +228,5 @@ rules:
   - patch
   - update
 {{- end }}
+{{- end}}
+

--- a/charts/m4d/templates/manager-cr.yaml
+++ b/charts/m4d/templates/manager-cr.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if eq .Values.clusterScoped "false"}}
+{{- if .Values.clusterScoped}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/m4d/templates/manager-cr.yaml
+++ b/charts/m4d/templates/manager-cr.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped}}
+{{- if .Values.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -228,5 +228,5 @@ rules:
   - patch
   - update
 {{- end }}
-{{- end}}
+{{- end }}
 

--- a/charts/m4d/templates/manager-crb.yaml
+++ b/charts/m4d/templates/manager-crb.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped}}
+{{- if .Values.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +13,4 @@ subjects:
   name: {{ .Values.manager.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- end}}
+{{- end }}

--- a/charts/m4d/templates/manager-crb.yaml
+++ b/charts/m4d/templates/manager-crb.yaml
@@ -1,4 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if eq .Values.clusterScoped "false"}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
   name: {{ .Values.manager.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- end}}

--- a/charts/m4d/templates/manager-crb.yaml
+++ b/charts/m4d/templates/manager-crb.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if eq .Values.clusterScoped "false"}}
+{{- if .Values.clusterScoped}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/m4d/templates/webhook-configs.yaml
+++ b/charts/m4d/templates/webhook-configs.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped}}
+{{- if .Values.clusterScoped }}
 {{ tpl ( .Files.Get "files/webhook-configs.yaml" ) . }}
-{{- end}}
-{{- end}}
+{{- end }}
+{{- end }}

--- a/charts/m4d/templates/webhook-configs.yaml
+++ b/charts/m4d/templates/webhook-configs.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if eq .Values.clusterScoped "false"}}
+{{- if .Values.clusterScoped}}
 {{ tpl ( .Files.Get "files/webhook-configs.yaml" ) . }}
 {{- end}}
 {{- end}}

--- a/charts/m4d/templates/webhook-configs.yaml
+++ b/charts/m4d/templates/webhook-configs.yaml
@@ -1,3 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if eq .Values.clusterScoped "false"}}
 {{ tpl ( .Files.Get "files/webhook-configs.yaml" ) . }}
+{{- end}}
 {{- end}}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -10,8 +10,8 @@ fullnameOverride: ""
 # Note that these resources are still required for a valid
 # deployment. Only set this to false if you deployed cluster
 # scoped resources using a different method.
-# TODO(roee.shlomo): not implemented yet, comparing this approach to using a base chart.
-# clusterScoped: true
+
+clusterScoped: true
 
 # Global configuration applies to multiple components installed by this chart
 global:


### PR DESCRIPTION
The `clusterScoped` flag is required to deploy M4D on the Operate First cluster using ArgoCD. This PR adds checks to each cluster-scoped resource Helm template, and will only deploy them if `clusterScoped` is `true`.