### PR TITLE
website: Add versioning support

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -9,19 +9,34 @@ on:
       - site/**
       - pkg/connectors/protos/**
       - charts/m4d-crd/templates/**
-
+  workflow_dispatch:
 jobs:
   website-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: version
+        name: Infer version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.8
       - name: Install Material for MkDocs
         run: |
           pip install mkdocs-material
+          pip install mike
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "noreply@github.com"
       - name: Build and Deploy
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         working-directory: ./site
-        run: mkdocs gh-deploy --force -r origin
+        run: mike deploy --push --remote origin --branch site ${RELEASE_VERSION}
+      - name: Set version alias
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mike alias ${RELEASE_VERSION} latest

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths:
       - site/**
+      - .github/workflows/website-*
       - pkg/connectors/protos/**
       - charts/m4d-crd/templates/**
   workflow_dispatch:
@@ -32,11 +33,11 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "noreply@github.com"
-      - name: Build and Deploy
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+      - name: Build and Deploy (dev)
+        if: github.ref == 'refs/heads/master'
         working-directory: ./site
-        run: mike deploy --push --remote origin --branch site ${RELEASE_VERSION}
-      - name: Set version alias
+        run: mike deploy --push --remote origin --branch site dev
+      - name: Build and Deploy (tag)
         if: startsWith(github.ref, 'refs/tags/')
-        run: mike alias ${RELEASE_VERSION} latest
+        working-directory: ./site
+        run: mike deploy --push --remote origin --branch site ${{ steps.version.outputs.version }} latest

--- a/site/docs/concepts/architecture.md
+++ b/site/docs/concepts/architecture.md
@@ -11,7 +11,7 @@ The primary interaction object for a data user is the `M4DApplication` CRD where
 
 ![Architecture](../static/workflow_multicluster.svg)
 
-Before the data user can perform any actions a data operator has to [install](../get-started/quickstart-v2.md) the Mesh for Data and modules. 
+Before the data user can perform any actions a data operator has to [install](../get-started/quickstart.md) the Mesh for Data and modules. 
 [Modules](./modules.md) are an extensible mechanism for processing data.
 Modules can provide read/write access or produce implicit copies that serve as lower latency caches of remote assets. Modules also enforce policies defined for data assets.
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -40,6 +40,8 @@ nav:
     - contribute/modules.md
 
 extra:
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ibm/the-mesh-for-data


### PR DESCRIPTION
* Updated website deployment to support versioning
* Tested in https://roee88.github.io/site-test
* Fixed wrong link in architecture.md

End result is "dev" version that always matches master + a version for each tag (with `latest` as an alias to the latest tag).

The deployment is to a branch named `site`. If all goes well I will change settings to serve the website from there and delete the gh-pages branch. 