### PR TITLE
Bring back code to register bucket credentials in Vault.

### DIFF
--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -80,6 +80,15 @@ func (m *ModuleManager) GetCopyDestination(item modules.DataInfo, destinationInt
 		m.Log.Info("Bucket allocation failed: " + err.Error())
 		return nil, err
 	}
+	credsMap, err := SecretToCredentialMap(m.Client, bucket.SecretRef)
+	if err != nil {
+		m.Log.Info("Could not fetch credentials: " + err.Error())
+		return nil, err
+	}
+	if err = m.VaultConnection.AddSecret(utils.GetVaultDatasetHome()+bucket.Name, credsMap); err != nil {
+		m.Log.Info("Could not register secret in vault: " + err.Error())
+		return nil, err
+	}
 	bucketRef := &types.NamespacedName{Name: bucket.Name, Namespace: utils.GetSystemNamespace()}
 	if err = m.Provision.CreateDataset(bucketRef, bucket, &m.Owner); err != nil {
 		m.Log.Info("Dataset creation failed: " + err.Error())


### PR DESCRIPTION
Signed-off-by: Revital Sur <eres@il.ibm.com>

The code to add a secret to Vault with the bucket credentials was accidentally removed in previous PR.
If CredentialLocation field is used to get bucket credentials from Vault then the Vault secret should be created properly.
This PR brings back the code to add such secret to Vault.