### PR TITLE
charts: added vault secret for manager

### DIFF
--- a/charts/m4d/templates/manager-deployment.yaml
+++ b/charts/m4d/templates/manager-deployment.yaml
@@ -78,6 +78,10 @@ spec:
             - secretRef:
                 name: razee-credentials
             {{- end }}
+            {{- if .Values.coordinator.enabled}}
+            - secretRef:
+                name: vault-credentials
+            {{- end }}
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
@@ -85,11 +89,6 @@ spec:
               value: {{ include "m4d.image" ( tuple $ .Values.mover ) }}
             - name: IMAGE_PULL_POLICY
               value: {{ .Values.mover.imagePullPolicy | default .Values.global.imagePullPolicy }}
-            - name: VAULT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: vault-unseal-keys
-                  key: vault-root
             {{- if .Values.manager.extraEnvs }}
             {{- toYaml .Values.manager.extraEnvs | nindent 12 }}
             {{- end }}

--- a/charts/m4d/templates/vault-credentials.yaml
+++ b/charts/m4d/templates/vault-credentials.yaml
@@ -1,0 +1,11 @@
+{{- if include "m4d.isEnabled" (tuple .Values.manager.enabled .Values.coordinator.enabled) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: vault-credentials
+data:
+  {{ if .Values.coordinator.vault.login.token }}
+  VAULT_TOKEN: {{ .Values.coordinator.vault.login.token | b64enc }}
+  {{ end }}
+{{- end }}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -77,6 +77,10 @@ coordinator:
   vault:
     # Set to the Vault address. 
     address: "http://vault.m4d-system:8200"
+    # Login method to Vault
+    login:
+      # Token authentication
+      token: "root"
     # Set to the path where credentials of dataset accessed by the m4d are stored.
     datasetHome: "m4d/dataset-creds/"
     # Set to the path where user credentials are stored.


### PR DESCRIPTION
Changes:
	- Added chart value `coordinator.vault.login.token` defaulted to "root".
	- Added a secret `vault-credentials` to that chart. This holds the token and is loaded by the manager to set VAULT_TOKEN (instead of taking it from `vault-unseal-keys`).
	- `vault-unseal-keys` generation is kept. See #477.