### PR TITLE
Change the expected error message from razee.

### DIFF
--- a/pkg/multicluster/razee/razee_cluster_manager.go
+++ b/pkg/multicluster/razee/razee_cluster_manager.go
@@ -188,7 +188,7 @@ func (r *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blu
 	// Check if channel exists
 	existingChannel, err := r.con.Channels.ChannelByName(r.orgID, channelName)
 	if err != nil {
-		if !strings.HasPrefix(err.Error(), "Query channelByName error. Could not find the channel with name") {
+		if !strings.HasPrefix(err.Error(), "Query channelByName error.") {
 			return err
 		}
 	}


### PR DESCRIPTION
IBM Cloud Satellite or Razee seem to have changed the error messages returned. They don't distinguish any more between channel not found and different errors.