### PR TITLE
Fix vault plugin-secrets-kubernetes-reader image name.

### DIFF
--- a/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
+++ b/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
@@ -9,7 +9,7 @@ server:
       readOnly: false
   extraInitContainers:
     - name: kubesecrets-plugin
-      image: ghcr.io/revit13/vault-plugin-secrets-kubernetes-reader:latest
+      image: ghcr.io/the-mesh-for-data/vault-plugin-secrets-kubernetes-reader:latest
       command: [/bin/sh, -ec]
       args:
         - cp /vault-plugin-secrets-kubernetes-reader /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader


### PR DESCRIPTION
Signed-off-by: Revital Sur <eres@il.ibm.com>

Fix #470 