### PR TITLE
Add values.yaml file to Vault chart for single cluster deployment.

### DIFF
--- a/third_party/vault/vault-single-cluster/values.yaml
+++ b/third_party/vault/vault-single-cluster/values.yaml
@@ -1,0 +1,54 @@
+server:
+  extraArgs: '-dev-plugin-dir=/usr/local/libexec/vault'
+  volumes:
+    - name: plugins
+      emptyDir: {}
+  volumeMounts:
+    - mountPath: /usr/local/libexec/vault
+      name: plugins
+      readOnly: false
+  extraInitContainers:
+    - name: kubesecrets-plugin
+      image: ghcr.io/the-mesh-for-data/vault-plugin-secrets-kubernetes-reader:latest
+      command: [/bin/sh, -ec]
+      args:
+        - cp /vault-plugin-secrets-kubernetes-reader /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader
+      volumeMounts:
+      - name: plugins
+        mountPath: /usr/local/libexec/vault
+        readOnly: false
+  extraEnvironmentVars:
+    VAULT_API_ADDR: http://127.0.0.1:8200
+    VAULT_ADDR: http://127.0.0.1:8200
+  # Used to define commands to run after the pod is ready.
+  # This can be used to automate processes such as initialization
+  # or boostrapping auth methods.
+  postStart:
+    - "sh"
+    - "-c"
+    # Sleep command is needed to avoid synchronization issues with the container pod. Please see
+    # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion
+    # FIXME: Use a proper way to configure Vault after Vault start-up
+    - | 
+      sleep 5
+      # configuring kubernetes auth method and use it later to create roles.
+      vault auth enable kubernetes
+      vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
+      # enable secret engine
+      vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader
+      # create policy to access secrets
+      # NOTE: m4d/dataset-creds/ secret engine is enabled by the manager and is used temporarily
+      # to store dataset credentials.
+      vault policy write "allow-all-dataset-creds" - <<EOF
+      path "m4d/dataset-creds/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+      }
+      path "kubernetes-secrets/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+      }
+      EOF
+      # allow modules running in m4d-blueprints namespace to access dataset credentials
+      vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="m4d-blueprints" policies="allow-all-dataset-creds" ttl=24h
+      # enable userpass auth method
+      vault auth enable userpass
+      vault write auth/userpass/users/data_provider password=password policies="allow-all-dataset-creds"


### PR DESCRIPTION
This PR adds a new values.yaml file to Vault helm chart which configures Vault for single cluster deployment as follows:

- Configures Kubernetes auth method in path called kubernetes: this auth path is used later to add roles for the modules and secret provider.
- Enables Kubernetes secret plugin reader
- Creates a policy to access secrets
- Creates a role to bind modules running in m4d-blueprint namespace to use the policy above.
- Creates userpass auth method.

This configuration completes the existing Vault configuration done in the manager:

 - Mounts secret engine for dataset credentials
 - Adds a policy to access it
 - Adds a role in kubernetes auth path for the secret provider to use the policy above
