### PR TITLE
Fix VAULT_DATASET_MOUNT in m4d-config ConfigMap.

### DIFF
--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -14,10 +14,10 @@ data:
   MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .Values.coordinator.policyManagerConnectorURL | default (printf "%s-connector:80" .Values.coordinator.policyManager) | quote }}
   USE_EXTENSIONPOLICY_MANAGER: "false" # deprecated
   VAULT_ADDRESS: {{ .Values.coordinator.vault.address | quote }}
-  VAULT_DATASET_HOME: {{ .Values.coordinator.vault.datasetHome | quote }} # temporary
-  VAULT_DATASET_MOUNT: {{ printf "/v1/sys/mounts/%s" .Values.coordinator.vault.datasetHome | quote }} # temporary
-  VAULT_USER_HOME: {{ .Values.coordinator.vault.userHome | quote}} # temporary
-  VAULT_USER_MOUNT: {{ printf "/v1/sys/mounts/%s" .Values.coordinator.vault.userHome | quote }} # temporary
+  VAULT_DATASET_HOME: {{ printf "m4d/dataset-creds/" | quote }} # temporary
+  VAULT_DATASET_MOUNT: {{ printf "/v1/sys/mounts/m4d/dataset-creds" | quote }} # temporary
+  VAULT_USER_HOME: {{ printf "m4d/user-creds/" | quote}} # temporary
+  VAULT_USER_MOUNT: {{ printf "/v1/sys/mounts/m4d/user-creds" | quote }} # temporary
   USER_VAULT_ADDRESS: {{ .Values.coordinator.vault.address | quote }} # deprecated
   USER_VAULT_PATH: "external" # deprecated
   SECRET_PROVIDER_URL: "http://secret-provider.m4d-system:5555/get-secret" # deprecated

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -81,10 +81,6 @@ coordinator:
     login:
       # Token authentication
       token: "root"
-    # Set to the path where credentials of dataset accessed by the m4d are stored.
-    datasetHome: "m4d/dataset-creds/"
-    # Set to the path where user credentials are stored.
-    userHome: "m4d/user-creds/"
 
   # Configures the Razee instance to be used by the coordinator manager in a multicluster setup
   razee:
@@ -193,7 +189,7 @@ secretProvider:
 
   # Image name or a hub/image[:tag]
   image: "secret-provider"
-  
+
   # Overrides global.imagePullPolicy
   imagePullPolicy: ""
 


### PR DESCRIPTION
This PR fixes VAULT_DATASET_MOUNT and VAULT_USER_MOUNT values in m4d-config ConfigMap. As the usage of VAULT_DATASET is temporary (to be removed after migration to Vault plugin will be complete) the value is hard coded.