### PR TITLE
Add possibility to do custom builds to fork's ghcr.io

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build-and-publish:
+    if: github.repository != 'IBM/the-mesh-for-data'
     name: Build and publish images
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -44,3 +44,5 @@ jobs:
     - run: echo "Pushing images to ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE} from branch ${{ github.ref }}"
     - name: Build and push docker images
       run: make docker
+    - name: Push helm charts
+      run: make -C modules helm-chart-push

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -42,5 +42,5 @@ jobs:
         key: ${{ runner.os }}-custom-m2-${{ hashFiles('**/pom.xml') }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-custom
     - run: echo "Pushing images to ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}"
-#    - name: Build and push docker images
-#      run: make docker
+    - name: Build and push docker images
+      run: make docker

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -41,6 +41,6 @@ jobs:
           ${{ github.workspace }}/hack/tools/bin
         key: ${{ runner.os }}-custom-m2-${{ hashFiles('**/pom.xml') }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-custom
-    - run: echo "Pushing images to ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}"
+    - run: echo "Pushing images to ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE} from branch ${{ github.ref }}"
     - name: Build and push docker images
       run: make docker

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -1,0 +1,46 @@
+name: Custom Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      dockerTag:
+        description: 'Docker Tag'
+        required: true
+        default: 'latest'
+
+env:
+  GO_VERSION: 1.13
+  JAVA_VERSION: 11
+
+jobs:
+  build-and-publish:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_HOSTNAME: "ghcr.io"
+      DOCKER_NAMESPACE: ${{ github.actor }}
+      DOCKER_TAG: ${{ github.event.inputs.dockerTag }}
+      DOCKER_USERNAME: ${{ github.actor }}
+      DOCKER_PASSWORD: ${{ github.token }}
+    steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - uses: actions/checkout@v2
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2/repository
+          ~/go/pkg/mod
+          ${{ github.workspace }}/hack/tools/bin
+        key: ${{ runner.os }}-custom-m2-${{ hashFiles('**/pom.xml') }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-custom
+    - run: echo "Pushing images to ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}"
+#    - name: Build and push docker images
+#      run: make docker


### PR DESCRIPTION
This will add the possibility to easily do custom build to the GitHub packages of a fork.
E.g. users can manually publish images produced by a branch to their GitHub container registry so that they can use them and try them out before doing a PR or merging to master.

Please tell me if the name "Custom build" is fine for this category or not.