### PR TITLE
charts: added missing m4d-blueprints namespace

### DIFF
--- a/charts/m4d/templates/m4d-blueprints-ns.yaml
+++ b/charts/m4d/templates/m4d-blueprints-ns.yaml
@@ -1,0 +1,8 @@
+{{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if .Values.clusterScoped }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: m4d-blueprints
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Fix #494

