### PR TITLE
Publish docker images and helm charts on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
   pull_request:
     branches:
       - master

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,9 @@ DOCKER_PUBLIC_NAMES := \
 	katalog-connector \
 	opa-connector \
 	vault-connector
- 
+
+TRAVIS_TAG := $(shell echo "$${GITHUB_REF\#refs/*/}")
+
 define do-docker-retag-and-push-public
 	for name in ${DOCKER_PUBLIC_NAMES}; do \
 		docker tag ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/$$name:${DOCKER_TAGNAME} ${DOCKER_PUBLIC_HOSTNAME}/${DOCKER_PUBLIC_NAMESPACE}/$$name:$1; \
@@ -134,14 +136,14 @@ endef
 .PHONY: docker-retag-and-push-public
 docker-retag-and-push-public:
 	$(call do-docker-retag-and-push-public,latest)
-ifneq (${TRAVIS_TAG},)
-	$(call do-docker-retag-and-push-public,${TRAVIS_TAG})
+ifneq (,$(findstring tags,$(GITHUB_REF)))
+	$(call do-docker-retag-and-push-public,$(TRAVIS_TAG))
 endif
 
 .PHONY: helm-push-public
 helm-push-public:
 	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} make -C modules helm-chart-push
-ifneq (${TRAVIS_TAG},)
+ifneq (,$(findstring tags,$(GITHUB_REF)))
 	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} DOCKER_TAGNAME=${TRAVIS_TAG} make -C modules helm-chart-push
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -135,16 +135,18 @@ endef
 
 .PHONY: docker-retag-and-push-public
 docker-retag-and-push-public:
-	$(call do-docker-retag-and-push-public,latest)
 ifneq (,$(findstring tags,$(GITHUB_REF)))
 	$(call do-docker-retag-and-push-public,$(TRAVIS_TAG))
+else
+	$(call do-docker-retag-and-push-public,latest)
 endif
 
 .PHONY: helm-push-public
 helm-push-public:
-	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} make -C modules helm-chart-push
 ifneq (,$(findstring tags,$(GITHUB_REF)))
 	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} DOCKER_TAGNAME=${TRAVIS_TAG} make -C modules helm-chart-push
+else
+	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} make -C modules helm-chart-push
 endif
 
 .PHONY: save-images


### PR DESCRIPTION
I decided to keep the logic in the make file. It seemed like less of a hack than the single github steps.

Although. If the make file is pushing latest and tag version tags for a tag build and the master branch is pushing latest. Aren't we pushing latest twice for the same commit? Shouldn't it be an either or as the CI is triggered twice?