### PR TITLE
change: mover image location

### DIFF
--- a/charts/m4d/templates/manager-deployment.yaml
+++ b/charts/m4d/templates/manager-deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - name: ENABLE_WEBHOOKS
               value: "true"
             - name: MOVER_IMAGE
-              value: {{ include "m4d.image" ( tuple $ .Values.mover ) }}
+              value: {{ .Values.mover.image }}
             - name: IMAGE_PULL_POLICY
               value: {{ .Values.mover.imagePullPolicy | default .Values.global.imagePullPolicy }}
             {{- if .Values.manager.extraEnvs }}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -107,9 +107,11 @@ worker:
 
 # Mover configuration used in the Mostion API controllers
 mover:
-  # Image name or a hub/image[:tag]
-  image: "mover"
-  # Overrides global.imagePullPolicy
+  # Default image for mover (format: hub/image[:tag])
+  image: "ghcr.io/mesh-for-data/mover:latest"
+  
+  # Default image pull policy for mover.
+  # Overrides global.imagePullPolicy.
   imagePullPolicy: ""
 
 # Manager component

--- a/manager/config/manager/manager.yaml
+++ b/manager/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - name: ENABLE_WEBHOOKS
             value: "true"
           - name: MOVER_IMAGE
-            value: "ghcr.io/the-mesh-for-data/mover:latest"
+            value: "ghcr.io/mesh-for-data/mover:latest"
           - name: IMAGE_PULL_POLICY
             value: "Always"
         resources:

--- a/modules/m4d-implicit-copy-batch/values.yaml
+++ b/modules/m4d-implicit-copy-batch/values.yaml
@@ -12,7 +12,7 @@
 # app_cluster:
 labels: {}
 
-image: "ghcr.io/the-mesh-for-data/mover:latest"
+image: ""
 imagePullPolicy: null
 noFinalizer: "true"
 

--- a/modules/m4d-implicit-copy-stream/values.yaml
+++ b/modules/m4d-implicit-copy-stream/values.yaml
@@ -5,7 +5,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: "ghcr.io/the-mesh-for-data/mover:latest"
+image: ""
 imagePullPolicy: null
 noFinalizer: "true"
 


### PR DESCRIPTION
* charts: mover image is fully qualified
* charts: updated comments for mover fields
* mover image changed to ghcr.io/mesh-for-data/mover:latest
* default values in modules do not specify image

@froesef I couldn't find where/why to change anything related to dummy mover. Also, is there a specific tag I should use?

Fix #500