### PR TITLE
Remove mover image config from m4d-config

### DIFF
--- a/charts/m4d/templates/manager-deployment.yaml
+++ b/charts/m4d/templates/manager-deployment.yaml
@@ -85,10 +85,6 @@ spec:
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-            - name: MOVER_IMAGE
-              value: {{ include "m4d.image" ( tuple $ .Values.mover ) }}
-            - name: IMAGE_PULL_POLICY
-              value: {{ .Values.mover.imagePullPolicy | default .Values.global.imagePullPolicy }}
             {{- if .Values.manager.extraEnvs }}
             {{- toYaml .Values.manager.extraEnvs | nindent 12 }}
             {{- end }}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -105,13 +105,6 @@ worker:
   # Set to false to disable worker components in manager.
   enabled: true
 
-# Mover configuration used in the Mostion API controllers
-mover:
-  # Image name or a hub/image[:tag]
-  image: "mover"
-  # Overrides global.imagePullPolicy
-  imagePullPolicy: ""
-
 # Manager component
 manager:
   # Set to true to deploy the manager component or false to skip its deployment.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/containerd/continuity v0.0.0-20201119173150-04c754faca46 // indirect
 	github.com/datashim-io/datashim/src/dataset-operator v0.0.0-20210322095623-e5d70b250696
-	github.com/deepmap/oapi-codegen v1.4.2 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/render v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -386,7 +386,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cznic/b v0.0.0-20180115125044-35e9bbe41f07/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
@@ -407,8 +406,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/deepmap/oapi-codegen v1.4.2 h1:boVMuW+o0sOnEDB8oWRobBm1BrD5d9bUtIQVcjwMsSk=
-github.com/deepmap/oapi-codegen v1.4.2/go.mod h1:1jY0YDxfBF3tXk1u3sARJMSUJa9wV0UrVT6o+2mr/zQ=
 github.com/deislabs/oras v0.7.0/go.mod h1:sqMKPG3tMyIX9xwXUBRLhZ24o+uT4y6jgBD2RzUTKDM=
 github.com/deislabs/oras v0.8.1 h1:If674KraJVpujYR00rzdi0QAmW4BxzMJPVAZJKuhQ0c=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
@@ -526,8 +523,6 @@ github.com/gammazero/workerpool v0.0.0-20190406235159-88d534f22b56/go.mod h1:w9R
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/getkin/kin-openapi v0.26.0 h1:xKIW5Z5wAfutxGBH+rr9qu0Ywfb/E1bPWkYLKRYfEuU=
-github.com/getkin/kin-openapi v0.26.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
@@ -538,7 +533,6 @@ github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG
 github.com/go-asn1-ber/asn1-ber v1.3.1 h1:gvPdv/Hr++TRFCl0UbPFHC54P9N9jgsRPnmnr419Uck=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-bindata/go-bindata v3.1.1+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
-github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
@@ -769,7 +763,6 @@ github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d/go.mod h1:ozx7R9S
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
 github.com/golangci/golangci-lint v1.31.0/go.mod h1:aMQuNCA+NDU5+4jLL5pEuFHoue0IznKE2+/GsFvvs8A=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc/go.mod h1:e5tpTHCfVze+7EpLEozzMB3eafxo2KT5veNg1k6byQU=
-github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca/go.mod h1:tvlJhZqDe4LMs4ZHD0oMUlt9G2LWuDGoisJTBzLMV9o=
 github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770/go.mod h1:dEbvlSfYbMQDtrpRMQU675gSDLDNa8sCPPChZ7PhiVA=
@@ -1189,10 +1182,6 @@ github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLg
 github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20200107223247-51020689f1fb/go.mod h1:WMXcpbGahPxQbYURxMYWPKXxFCw2o4saIl/x3iH68Rg=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
-github.com/labstack/echo/v4 v4.1.11 h1:z0BZoArY4FqdpUEl+wlHp4hnr/oSR6MTmQmv8OHSoww=
-github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
-github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
-github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
@@ -1243,7 +1232,6 @@ github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11 h1:YFh+sjyJ
 github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11/go.mod h1:Ah2dBMoxZEqk118as2T4u4fjfXarE0pPnMJaArZQZsI=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
-github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1256,7 +1244,6 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -1720,12 +1707,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=
-github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.15.1/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
-github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy1Ocw4=
-github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/quicktemplate v1.6.2/go.mod h1:mtEJpQtUiBV0SHhMX6RtiJtqxncgrfmjcUy5T68X8TM=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
@@ -1848,7 +1831,6 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -2024,7 +2006,6 @@ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2038,7 +2019,6 @@ golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -44,7 +44,7 @@ func (r *BatchTransfer) Default() {
 	log.Printf("Defaulting batchtransfer %s", r.Name)
 	if r.Spec.Image == "" {
 		// TODO check if can be removed after upgrading controller-gen to 0.5.0
-		r.Spec.Image = "ghcr.io/the-mesh-for-data/mover:latest"
+		r.Spec.Image = "ghcr.io/mesh-for-data/mover:latest"
 	}
 
 	if r.Spec.ImagePullPolicy == "" {

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -43,17 +43,13 @@ const DefaultSuccessfulJobHistoryLimit = 5
 func (r *BatchTransfer) Default() {
 	log.Printf("Defaulting batchtransfer %s", r.Name)
 	if r.Spec.Image == "" {
-		if env, b := os.LookupEnv("MOVER_IMAGE"); b {
-			r.Spec.Image = env
-		}
+		// TODO check if can be removed after upgrading controller-gen to 0.5.0
+		r.Spec.Image = "ghcr.io/the-mesh-for-data/mover:latest"
 	}
 
 	if r.Spec.ImagePullPolicy == "" {
-		if env, b := os.LookupEnv("IMAGE_PULL_POLICY"); b {
-			r.Spec.ImagePullPolicy = v1.PullPolicy(env)
-		} else {
-			r.Spec.ImagePullPolicy = v1.PullIfNotPresent
-		}
+		// TODO check if can be removed after upgrading controller-gen to 0.5.0
+		r.Spec.ImagePullPolicy = v1.PullIfNotPresent
 	}
 
 	if r.Spec.SecretProviderURL == "" {

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -180,8 +180,6 @@ func TestInvalidS3Bucket(t *testing.T) {
 
 func TestDefaultingS3Bucket(t *testing.T) {
 	t.Parallel()
-	_ = os.Setenv("IMAGE_PULL_POLICY", "Always")
-	_ = os.Setenv("MOVER_IMAGE", "mover-test:latest")
 	_ = os.Setenv("SECRET_PROVIDER_URL", "mysecrets:123")
 	_ = os.Setenv("SECRET_PROVIDER_ROLE", "demo")
 
@@ -231,7 +229,7 @@ func TestDefaultingS3Bucket(t *testing.T) {
 	batchTransfer.Default()
 
 	assert.Equal(t, corev1.PullAlways, batchTransfer.Spec.ImagePullPolicy)
-	assert.Equal(t, "mover-test:latest", batchTransfer.Spec.Image)
+	assert.Equal(t, "ghcr.io/the-mesh-for-data/mover:latest", batchTransfer.Spec.Image)
 	assert.Equal(t, "mysecrets:123", batchTransfer.Spec.SecretProviderURL)
 	assert.Equal(t, "demo", batchTransfer.Spec.SecretProviderRole)
 	assert.Equal(t, false, batchTransfer.Spec.Suspend)
@@ -244,7 +242,6 @@ func TestDefaultingS3Bucket(t *testing.T) {
 	assert.Equal(t, LogData, batchTransfer.Spec.WriteDataType)
 	assert.Equal(t, Overwrite, batchTransfer.Spec.WriteOperation)
 	_ = os.Unsetenv("IMAGE_PULL_POLICY")
-	_ = os.Unsetenv("MOVER_IMAGE")
 	_ = os.Unsetenv("SECRET_PROVIDER_URL")
 	_ = os.Unsetenv("SECRET_PROVIDER_ROLE")
 }

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -229,7 +229,7 @@ func TestDefaultingS3Bucket(t *testing.T) {
 	batchTransfer.Default()
 
 	assert.Equal(t, corev1.PullIfNotPresent, batchTransfer.Spec.ImagePullPolicy)
-	assert.Equal(t, "ghcr.io/the-mesh-for-data/mover:latest", batchTransfer.Spec.Image)
+	assert.Equal(t, "ghcr.io/mesh-for-data/mover:latest", batchTransfer.Spec.Image)
 	assert.Equal(t, "mysecrets:123", batchTransfer.Spec.SecretProviderURL)
 	assert.Equal(t, "demo", batchTransfer.Spec.SecretProviderRole)
 	assert.Equal(t, false, batchTransfer.Spec.Suspend)

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -228,7 +228,7 @@ func TestDefaultingS3Bucket(t *testing.T) {
 
 	batchTransfer.Default()
 
-	assert.Equal(t, corev1.PullAlways, batchTransfer.Spec.ImagePullPolicy)
+	assert.Equal(t, corev1.PullIfNotPresent, batchTransfer.Spec.ImagePullPolicy)
 	assert.Equal(t, "ghcr.io/the-mesh-for-data/mover:latest", batchTransfer.Spec.Image)
 	assert.Equal(t, "mysecrets:123", batchTransfer.Spec.SecretProviderURL)
 	assert.Equal(t, "demo", batchTransfer.Spec.SecretProviderRole)
@@ -241,7 +241,6 @@ func TestDefaultingS3Bucket(t *testing.T) {
 	assert.Equal(t, LogData, batchTransfer.Spec.ReadDataType)
 	assert.Equal(t, LogData, batchTransfer.Spec.WriteDataType)
 	assert.Equal(t, Overwrite, batchTransfer.Spec.WriteOperation)
-	_ = os.Unsetenv("IMAGE_PULL_POLICY")
 	_ = os.Unsetenv("SECRET_PROVIDER_URL")
 	_ = os.Unsetenv("SECRET_PROVIDER_ROLE")
 }

--- a/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
@@ -32,17 +32,13 @@ var _ webhook.Defaulter = &StreamTransfer{}
 func (r *StreamTransfer) Default() {
 	log.Printf("Defaulting streamtransfer %s", r.Name)
 	if r.Spec.Image == "" {
-		if env, b := os.LookupEnv("MOVER_IMAGE"); b {
-			r.Spec.Image = env
-		}
+		// TODO check if can be removed after upgrading controller-gen to 0.5.0
+		r.Spec.Image = "ghcr.io/the-mesh-for-data/mover:latest"
 	}
 
 	if r.Spec.ImagePullPolicy == "" {
-		if env, b := os.LookupEnv("IMAGE_PULL_POLICY"); b {
-			r.Spec.ImagePullPolicy = v1.PullPolicy(env)
-		} else {
-			r.Spec.ImagePullPolicy = v1.PullIfNotPresent
-		}
+		// TODO check if can be removed after upgrading controller-gen to 0.5.0
+		r.Spec.ImagePullPolicy = v1.PullIfNotPresent
 	}
 
 	if r.Spec.SecretProviderURL == "" {

--- a/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
@@ -33,7 +33,7 @@ func (r *StreamTransfer) Default() {
 	log.Printf("Defaulting streamtransfer %s", r.Name)
 	if r.Spec.Image == "" {
 		// TODO check if can be removed after upgrading controller-gen to 0.5.0
-		r.Spec.Image = "ghcr.io/the-mesh-for-data/mover:latest"
+		r.Spec.Image = "ghcr.io/mesh-for-data/mover:latest"
 	}
 
 	if r.Spec.ImagePullPolicy == "" {

--- a/manager/config/integration-tests/manager_patch.yaml
+++ b/manager/config/integration-tests/manager_patch.yaml
@@ -23,10 +23,6 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: MOVER_IMAGE
-          value: "localhost:5000/m4d-system/dummy-mover:latest"
-        - name: IMAGE_PULL_POLICY
-          value: "IfNotPresent"
         - name: NO_FINALIZER
           value: "false"
         - name: GODEBUG

--- a/manager/config/manager/manager.yaml
+++ b/manager/config/manager/manager.yaml
@@ -31,10 +31,6 @@ spec:
         env:
           - name: ENABLE_WEBHOOKS
             value: "true"
-          - name: MOVER_IMAGE
-            value: "ghcr.io/the-mesh-for-data/mover:latest"
-          - name: IMAGE_PULL_POLICY
-            value: "Always"
         resources:
           limits:
             cpu: 500m

--- a/manager/config/multi-controller/manager_patch.yaml
+++ b/manager/config/multi-controller/manager_patch.yaml
@@ -17,8 +17,6 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: IMAGE_PULL_POLICY
-          value: "IfNotPresent"
         - name: NO_FINALIZER
           value: "false"
         - name: GODEBUG

--- a/manager/config/multi-follower/manager_patch.yaml
+++ b/manager/config/multi-follower/manager_patch.yaml
@@ -22,8 +22,6 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: IMAGE_PULL_POLICY
-          value: "IfNotPresent"
         - name: NO_FINALIZER
           value: "false"
         - name: GODEBUG

--- a/manager/config/multi-integration-tests/manager_patch.yaml
+++ b/manager/config/multi-integration-tests/manager_patch.yaml
@@ -17,10 +17,6 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: MOVER_IMAGE
-          value: "localhost:5000/m4d-system/dummy-mover:latest"
-        - name: IMAGE_PULL_POLICY
-          value: "IfNotPresent"
         - name: NO_FINALIZER
           value: "false"
         - name: GODEBUG

--- a/manager/config/prod/manager_patch.yaml
+++ b/manager/config/prod/manager_patch.yaml
@@ -17,7 +17,5 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: IMAGE_PULL_POLICY
-          value: "IfNotPresent"
         - name: NO_FINALIZER
           value: "false"

--- a/manager/config/test/manager_patch.yaml
+++ b/manager/config/test/manager_patch.yaml
@@ -17,7 +17,5 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: IMAGE_PULL_POLICY
-          value: "Always"
         - name: NO_FINALIZER
           value: "true"

--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -125,6 +125,9 @@ func createModules() {
 			},
 			Chart: apiv1alpha1.ChartSpec{
 				Name: "db2-chart",
+				Values: map[string]string{
+					"image": "localhost:5000/m4d-system/dummy-mover:latest",
+				},
 			},
 		},
 	}
@@ -156,6 +159,9 @@ func createModules() {
 			},
 			Chart: apiv1alpha1.ChartSpec{
 				Name: "s3-s3",
+				Values: map[string]string{
+					"image": "localhost:5000/m4d-system/dummy-mover:latest",
+				},
 			},
 		},
 	}

--- a/modules/m4d-implicit-copy-batch/values.yaml
+++ b/modules/m4d-implicit-copy-batch/values.yaml
@@ -12,7 +12,7 @@
 # app_cluster:
 labels: {}
 
-image: "ghcr.io/the-mesh-for-data/mover:latest"
+image: "ghcr.io/mesh-for-data/mover:latest"
 imagePullPolicy: null
 noFinalizer: "true"
 

--- a/modules/m4d-implicit-copy-stream/values.yaml
+++ b/modules/m4d-implicit-copy-stream/values.yaml
@@ -5,7 +5,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: "ghcr.io/the-mesh-for-data/mover:latest"
+image: "ghcr.io/mesh-for-data/mover:latest"
 imagePullPolicy: null
 noFinalizer: "true"
 


### PR DESCRIPTION
This PR fixes #500 and make the standard image configurable in the m4d module and not any more as a global configuration in the m4d-config configmap.