### PR TITLE
ci: fixes to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,17 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: docker load -i images.tar
     - run: docker images
+    - id: version
+      name: Infer version
+      run: |
+        version="${GITHUB_REF#refs/tags/v}"
+        if  [[ $version == refs/* ]] ;
+        then
+            version="latest"
+        fi
+        echo ::set-output name=version::$version
     - name: Publish images
       if: ${{ github.event_name != 'pull_request' }}
+      env:
+        DOCKER_PUBLIC_TAGNAME:  ${{ steps.version.outputs.version }}
       run: make docker-retag-and-push-public && make helm-push-public

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -29,6 +30,7 @@ jobs:
         with:
           app_id: ${{ secrets.CHARTS_APP_ID }}
           private_key: ${{ secrets.CHARTS_APP_PRIVATE_KEY }}
+          repository: mesh-for-data/charts
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/charts/m4d-crd/Chart.yaml
+++ b/charts/m4d-crd/Chart.yaml
@@ -9,9 +9,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
+version: 0.0.1
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Currently set to latest until
-# the first release is available.
-appVersion: "latest"
+# incremented each time you make changes to the application. 
+appVersion: "0.0.1"

--- a/charts/m4d/Chart.yaml
+++ b/charts/m4d/Chart.yaml
@@ -9,9 +9,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
+version: 0.0.1
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Currently set to latest until
-# the first release is available.
-appVersion: "latest"
+# incremented each time you make changes to the application.
+appVersion: "0.0.1"


### PR DESCRIPTION
Required for https://github.com/IBM/the-mesh-for-data/issues/505

Fixes:
1. chart version as semver without v*
2. image tags as semver without v*
3. Missing `repository` item in chart publish workflow