### PR TITLE
Use local schema instead of global schema

### DIFF
--- a/manager/controllers/app/m4dapplication_controller_unit_test.go
+++ b/manager/controllers/app/m4dapplication_controller_unit_test.go
@@ -54,11 +54,7 @@ func TestM4DApplicationControllerCSVCopyAndRead(t *testing.T) {
 	}
 
 	// Register operator types with the runtime scheme.
-	s := runtime.NewScheme()
-	err = corev1.AddToScheme(s)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	err = app.AddToScheme(s)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	s := utils.NewScheme(g)
 
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)

--- a/manager/controllers/app/m4dapplication_controller_unit_test.go
+++ b/manager/controllers/app/m4dapplication_controller_unit_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -55,8 +54,10 @@ func TestM4DApplicationControllerCSVCopyAndRead(t *testing.T) {
 	}
 
 	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
-	err = app.AddToScheme(scheme.Scheme)
+	s := runtime.NewScheme()
+	err = corev1.AddToScheme(s)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	err = app.AddToScheme(s)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Create a fake client to mock API calls.

--- a/manager/controllers/app/plotter_controller_unit_test.go
+++ b/manager/controllers/app/plotter_controller_unit_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,7 +49,7 @@ func TestPlotterController(t *testing.T) {
 	}
 
 	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
+	s := runtime.NewScheme()
 	s.AddKnownTypes(app.GroupVersion, plotter)
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)

--- a/manager/controllers/app/plotter_controller_unit_test.go
+++ b/manager/controllers/app/plotter_controller_unit_test.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/ibm/the-mesh-for-data/manager/controllers/utils"
+
 	app "github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
 	"github.com/ibm/the-mesh-for-data/pkg/multicluster/dummy"
 	"github.com/onsi/gomega"
@@ -49,8 +51,7 @@ func TestPlotterController(t *testing.T) {
 	}
 
 	// Register operator types with the runtime scheme.
-	s := runtime.NewScheme()
-	s.AddKnownTypes(app.GroupVersion, plotter)
+	s := utils.NewScheme(g)
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	dummyManager := &dummy.ClusterManager{

--- a/manager/controllers/motion/batchtransfer_controller.go
+++ b/manager/controllers/motion/batchtransfer_controller.go
@@ -76,7 +76,7 @@ func (reconciler *BatchTransferReconciler) Reconcile(req ctrl.Request) (ctrl.Res
 		job := &kbatch.Job{}
 		if err := reconciler.Get(ctx, batchTransfer.ObjectKey(), job); err != nil {
 			if !kerrors.IsNotFound(err) {
-				log.Error(err, "could not fetch Job for batchTransfer %s", batchTransfer.ObjectKey())
+				log.Error(err, "could not fetch Job for batchTransfer %s", "batchTransfer", batchTransfer.ObjectKey())
 				return ctrl.Result{}, err
 			}
 			// If job was not found just continue...

--- a/manager/controllers/motion/batchtransfer_controller_unit_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_unit_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/onsi/gomega"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -17,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -31,6 +32,7 @@ func TestBatchTransferController(t *testing.T) {
 	t.Parallel()
 	// Set the logger to development mode for verbose logs.
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	g := gomega.NewGomegaWithT(t)
 
 	var (
 		name      = "sample-transfer"
@@ -70,7 +72,11 @@ func TestBatchTransferController(t *testing.T) {
 	}
 
 	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
+	s := runtime.NewScheme()
+	err := corev1.AddToScheme(s)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	err = kbatch.AddToScheme(s)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	s.AddKnownTypes(motionv1.GroupVersion, batchTransfer)
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)

--- a/manager/controllers/motion/batchtransfer_controller_unit_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_unit_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ibm/the-mesh-for-data/manager/controllers/utils"
+
 	"github.com/onsi/gomega"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -72,12 +74,7 @@ func TestBatchTransferController(t *testing.T) {
 	}
 
 	// Register operator types with the runtime scheme.
-	s := runtime.NewScheme()
-	err := corev1.AddToScheme(s)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	err = kbatch.AddToScheme(s)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	s.AddKnownTypes(motionv1.GroupVersion, batchTransfer)
+	s := utils.NewScheme(g)
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	// Create a BatchTransferReconciler object with the scheme and fake client.

--- a/manager/controllers/utils/test_utils.go
+++ b/manager/controllers/utils/test_utils.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	app "github.com/ibm/the-mesh-for-data/manager/apis/app/v1alpha1"
+	motionv1 "github.com/ibm/the-mesh-for-data/manager/apis/motion/v1alpha1"
+	"github.com/onsi/gomega"
+	kbatch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Creates a scheme that can be used in unit tests
+// The scheme will have the core and batch apis from K8s registered as well as
+// the app and motion apis from M4D.
+// This function can be tested with a gomega environment if passed or otherwise (if nil is passed) it will ignore tests.
+func NewScheme(g *gomega.WithT) *runtime.Scheme {
+	s := runtime.NewScheme()
+	err := corev1.AddToScheme(s)
+	if g != nil {
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+	err = kbatch.AddToScheme(s)
+	if g != nil {
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+	err = app.AddToScheme(s)
+	if g != nil {
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+	err = motionv1.AddToScheme(s)
+	if g != nil {
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+	return s
+}


### PR DESCRIPTION
Some tests had trouble when running in parallel. This PR changes the scheme to be local for the tests that are run in parallel.