### PR TITLE
full path to user credentials

### DIFF
--- a/manager/controllers/app/data_catalog_interface.go
+++ b/manager/controllers/app/data_catalog_interface.go
@@ -107,7 +107,7 @@ func (r *M4DApplicationReconciler) RegisterAsset(catalogID string, info *app.Dat
 	}
 	var credentialPath string
 	if input.Spec.SecretRef != "" {
-		credentialPath = vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
+		credentialPath = utils.GetVaultAddress() + vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
 	}
 
 	response, err := c.RegisterDatasetInfo(ctx, &pb.RegisterAssetRequest{

--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -396,7 +396,7 @@ func (r *M4DApplicationReconciler) constructDataInfo(req *modules.DataInfo, inpu
 	var response *pb.CatalogDatasetInfo
 	var credentialPath string
 	if input.Spec.SecretRef != "" {
-		credentialPath = vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
+		credentialPath = utils.GetVaultAddress() + vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -418,10 +418,6 @@ func (r *M4DApplicationReconciler) constructDataInfo(req *modules.DataInfo, inpu
 	req.VaultSecretPath = ""
 	if details.CredentialsInfo != nil {
 		req.VaultSecretPath = details.CredentialsInfo.VaultSecretPath
-	}
-
-	if input.Spec.SecretRef != "" {
-		credentialPath = vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
 	}
 
 	// Call the CredentialsManager service to get info about the dataset

--- a/manager/controllers/app/policy_compiler_interface.go
+++ b/manager/controllers/app/policy_compiler_interface.go
@@ -16,7 +16,7 @@ import (
 func ConstructApplicationContext(datasetID string, input *app.M4DApplication, operation *pb.AccessOperation) *pb.ApplicationContext {
 	var credentialPath string
 	if input.Spec.SecretRef != "" {
-		credentialPath = vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
+		credentialPath = utils.GetVaultAddress() + vault.PathForReadingKubeSecret(input.Namespace, input.Spec.SecretRef)
 	}
 	return &pb.ApplicationContext{
 		AppInfo: &pb.ApplicationDetails{


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@il.ibm.com>

This PR passes full path to user credentials in vault instead of a relative one.