### PR TITLE
Add tests for implicit copy module definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ run-integration-tests:
 	$(MAKE) helm
 	$(MAKE) -C pkg/helm test
 	$(MAKE) -C manager run-integration-tests
+	$(MAKE) -C modules test
 
 .PHONY: run-deploy-tests
 run-deploy-tests: export KUBE_NAMESPACE?=m4d-system

--- a/charts/m4d-crd/templates/app.m4d.ibm.com_m4dapplications.yaml
+++ b/charts/m4d-crd/templates/app.m4d.ibm.com_m4dapplications.yaml
@@ -80,6 +80,7 @@ spec:
                             - csv
                             - json
                             - avro
+                            - orc
                             - binary
                             - arrow
                             type: string

--- a/charts/m4d-crd/templates/app.m4d.ibm.com_m4dmodules.yaml
+++ b/charts/m4d-crd/templates/app.m4d.ibm.com_m4dmodules.yaml
@@ -56,6 +56,7 @@ spec:
                       - csv
                       - json
                       - avro
+                      - orc
                       - binary
                       - arrow
                       type: string
@@ -110,6 +111,7 @@ spec:
                             - csv
                             - json
                             - avro
+                            - orc
                             - binary
                             - arrow
                             type: string
@@ -135,6 +137,7 @@ spec:
                             - csv
                             - json
                             - avro
+                            - orc
                             - binary
                             - arrow
                             type: string

--- a/manager/apis/app/v1alpha1/ifdetails.go
+++ b/manager/apis/app/v1alpha1/ifdetails.go
@@ -8,7 +8,7 @@ package v1alpha1
 type IFProtocol string
 
 // DataFormatType defines data format type
-// +kubebuilder:validation:Enum=parquet;table;csv;json;avro;binary;arrow
+// +kubebuilder:validation:Enum=parquet;table;csv;json;avro;orc;binary;arrow
 type DataFormatType string
 
 // DataFormatType valid values
@@ -18,6 +18,7 @@ const (
 	CSV     DataFormatType = "csv"
 	JSON    DataFormatType = "json"
 	AVRO    DataFormatType = "avro"
+	ORC     DataFormatType = "orc"
 	Binary  DataFormatType = "binary"
 	Arrow   DataFormatType = "arrow"
 )

--- a/manager/config/crd/bases/app.m4d.ibm.com_m4dapplications.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_m4dapplications.yaml
@@ -80,6 +80,7 @@ spec:
                             - csv
                             - json
                             - avro
+                            - orc
                             - binary
                             - arrow
                             type: string

--- a/manager/config/crd/bases/app.m4d.ibm.com_m4dmodules.yaml
+++ b/manager/config/crd/bases/app.m4d.ibm.com_m4dmodules.yaml
@@ -56,6 +56,7 @@ spec:
                       - csv
                       - json
                       - avro
+                      - orc
                       - binary
                       - arrow
                       type: string
@@ -110,6 +111,7 @@ spec:
                             - csv
                             - json
                             - avro
+                            - orc
                             - binary
                             - arrow
                             type: string
@@ -135,6 +137,7 @@ spec:
                             - csv
                             - json
                             - avro
+                            - orc
                             - binary
                             - arrow
                             type: string

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,3 +1,5 @@
+ROOT_DIR := ..
+include $(ROOT_DIR)/Makefile.env
 NAME := m4d-template
 
 .PHONY: all
@@ -25,3 +27,11 @@ helm-uninstall:
 	$(MAKE) -C m4d-template helm-uninstall
 	$(MAKE) -C m4d-implicit-copy-batch helm-uninstall
 	$(MAKE) -C m4d-implicit-copy-stream helm-uninstall
+
+# Tests if implicit copy definitions can be installed
+.PHONY: test
+test:
+	$(TOOLBIN)/kubectl apply -f implicit-copy-batch-module.yaml
+	$(TOOLBIN)/kubectl apply -f implicit-copy-stream-module.yaml
+	$(TOOLBIN)/kubectl delete -f implicit-copy-batch-module.yaml
+	$(TOOLBIN)/kubectl delete -f implicit-copy-stream-module.yaml

--- a/samples/gui/front-end/src/formats/InputDataTable.js
+++ b/samples/gui/front-end/src/formats/InputDataTable.js
@@ -28,6 +28,11 @@ const formatOptions = [
     value: 'avro'
   },
   {
+    key: 'orc',
+    text: 'orc',
+    value: 'orc'
+  },
+  {
     key: 'binary',
     text: 'binary',
     value: 'binary'


### PR DESCRIPTION
Somehow the implicit copy module definitions were giving an error when deploying as ORC is not supported as format.

I fixed it by adding the ORC format and added a simple deploy in the integration tests so that future regression bugs are covered.