### PR TITLE
Change S3 endpoint validation to accept URLs instead of just hosts

### DIFF
--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -211,7 +211,7 @@ func validateDataStore(path *field.Path, store *DataStore) []*field.Error {
 		s3Path := path.Child("s3")
 		_, err := url.Parse(store.S3.Endpoint)
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(s3Path.Child("endpoint"), store.S3.Endpoint, "Invalid endpoint! Expecting a valid domain!"))
+			allErrs = append(allErrs, field.Invalid(s3Path.Child("endpoint"), store.S3.Endpoint, "Invalid endpoint! Expecting a endpoint URL!"))
 		}
 
 		if len(store.S3.Bucket) == 0 {

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -209,7 +209,8 @@ func validateDataStore(path *field.Path, store *DataStore) []*field.Error {
 
 	if store.S3 != nil {
 		s3Path := path.Child("s3")
-		if msgs := validationutils.IsDNS1123Subdomain(store.S3.Endpoint); len(msgs) != 0 {
+		_, err := url.Parse(store.S3.Endpoint)
+		if err != nil {
 			allErrs = append(allErrs, field.Invalid(s3Path.Child("endpoint"), store.S3.Endpoint, "Invalid endpoint! Expecting a valid domain!"))
 		}
 

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -195,11 +195,16 @@ func TestValidS3Bucket(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test http endpoint
+	datastore.S3.Endpoint = "http://localhost"
+	err = validateDataStore(path, &datastore)
+	assert.Nil(t, err)
+
+	// test http endpoint with host
 	datastore.S3.Endpoint = "http://localhost:9090"
 	err = validateDataStore(path, &datastore)
 	assert.Nil(t, err)
 
-	// test https endpoint
+	// test https endpoint with host
 	datastore.S3.Endpoint = "https://localhost:9091"
 	err = validateDataStore(path, &datastore)
 	assert.Nil(t, err)

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -164,12 +164,50 @@ func TestInvalidS3Bucket(t *testing.T) {
 	assert.Equal(t, "spec.source.s3.objectKey", err[0].Field)
 
 	// Test multiple errors
-	datastore.S3.Endpoint = "test@wrong.com"
+	datastore.S3.Endpoint = "123://wrong.com"
 	datastore.S3.Bucket = ""
 	datastore.S3.ObjectKey = ""
 	err = validateDataStore(path, &datastore)
 	assert.NotNil(t, err)
 	assert.Len(t, err, 3)
+}
+
+func TestValidS3Bucket(t *testing.T) {
+	t.Parallel()
+	datastore := DataStore{
+		Database: nil,
+		S3: &S3{
+			Endpoint:   "my.endpoint",
+			Region:     "eu-gb",
+			Bucket:     "mybucket",
+			AccessKey:  "ab",
+			SecretKey:  "cd",
+			ObjectKey:  "obj.parq",
+			DataFormat: "parquet",
+		},
+		Kafka: nil,
+	}
+
+	path := field.NewPath("spec", "source")
+
+	// test normal endpoint
+	err := validateDataStore(path, &datastore)
+	assert.Nil(t, err)
+
+	// test http endpoint
+	datastore.S3.Endpoint = "http://localhost:9090"
+	err = validateDataStore(path, &datastore)
+	assert.Nil(t, err)
+
+	// test https endpoint
+	datastore.S3.Endpoint = "https://localhost:9091"
+	err = validateDataStore(path, &datastore)
+	assert.Nil(t, err)
+
+	// test endpoint without scheme endpoint
+	datastore.S3.Endpoint = "localhost:9091"
+	err = validateDataStore(path, &datastore)
+	assert.Nil(t, err)
 }
 
 func TestDefaultingS3Bucket(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Florian Froese <ffr@zurich.ibm.com>