### PR TITLE
Upgrade maven protoc plugin 

### DIFF
--- a/connectors/egeria/pom.xml
+++ b/connectors/egeria/pom.xml
@@ -174,11 +174,7 @@
 			</snapshots>
 			<id>central</id>
 			<name>Central Repository</name>
-			<url>https://repo.maven.apache.org/maven2</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>protoc-plugin</id>
-			<url>https://dl.bintray.com/sergei-ivanov/maven/</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</pluginRepository>
 	</pluginRepositories>
 	<build>
@@ -196,9 +192,9 @@
 		</extensions>
 		<plugins>
 			<plugin>
-				<groupId>com.google.protobuf.tools</groupId>
-				<artifactId>maven-protoc-plugin</artifactId>
-				<version>0.4.2</version>
+				<groupId>org.xolstice.maven.plugins</groupId>
+				<artifactId>protobuf-maven-plugin</artifactId>
+				<version>0.6.1</version>
 				<configuration>
 					<!--
 	      The version of protoc must match protobuf-java. If you don't depend on
@@ -206,12 +202,9 @@
 	      protobuf-java version that grpc depends on.
 	  -->
 					<protoSourceRoot>${project.basedir}/../../pkg/connectors/protos/</protoSourceRoot>
-					<!-- <protoSourceRoot>${project.basedir}/../../service/protos-catalogconnector/</protoSourceRoot> -->
-					<protocArtifact>com.google.protobuf:protoc:3.0.0-beta-1:exe:${os.detected.classifier}</protocArtifact>
+					<protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
 					<pluginId>grpc-java</pluginId>
-					<!-- using newer grpc version to address exception handling -->
-					<!-- <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.9.0:exe:${os.detected.classifier}</pluginArtifact> -->
-					<pluginArtifact>io.grpc:protoc-gen-grpc-java:1.29.0:exe:${os.detected.classifier}</pluginArtifact>
+					<pluginArtifact>io.grpc:protoc-gen-grpc-java:1.37.0:exe:${os.detected.classifier}</pluginArtifact>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
This PR upgrades maven proton plugin. 
Reason: 
CI integration tests are failing with the following message:
Error:  Plugin com.google.protobuf.tools:maven-protoc-plugin:0.4.2 or one of its dependencies could not be resolved: Failed to read artifact descriptor for com.google.protobuf.tools:maven-protoc-plugin:jar:0.4.2: Could not transfer artifact com.google.protobuf.tools:maven-protoc-plugin:pom:0.4.2 from/to protoc-plugin (https://dl.bintray.com/sergei-ivanov/maven/): authorization failed for https://dl.bintray.com/sergei-ivanov/maven/com/google/protobuf/tools/maven-protoc-plugin/0.4.2/maven-protoc-plugin-0.4.2.pom, status: 403 Forbidden

Fix in this PR: 
Maven contacts bintray for getting the maven Protocol dependencies. Apparently bintray is being sunset (https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) from May 1 2021 as it was a free service. 
This PR changes the maven Protoc plugin to get the binary from the maven central repository. 

Signed-off-by: rohithdv <rovallam@in.ibm.com>