### PR TITLE
Change references of "purpose" to "intent" in opa 

### DIFF
--- a/charts/m4d/files/opa-server/policy-lib/helper_functions.rego
+++ b/charts/m4d/files/opa-server/policy-lib/helper_functions.rego
@@ -40,8 +40,8 @@ column_has_tag(tag) {
 	compare_str(tag, input.details.metadata.components_metadata[_].tags[_])
 }
 
-check_purpose(purpose) {
-    compare_str(purpose, Purpose())
+check_intent(intent) {
+    compare_str(intent, Intent())
 }
 
 check_role(role) {

--- a/charts/m4d/files/opa-server/policy-lib/input_reader.rego
+++ b/charts/m4d/files/opa-server/policy-lib/input_reader.rego
@@ -1,6 +1,6 @@
 package data_policies
 
-#this file assumes input to be provided in specific format, in this case how data mesh provides it 
+#this file assumes input to be provided in specific format, in this case how data mesh provides it
 #similar file can be built for Egeria, at least for the metadata part, or any other catalog when we show how the input should be  parsed correctly
 
 #Example structure:
@@ -46,11 +46,11 @@ package data_policies
 # }
 Properties() = input.properties
 
-Purpose() = Properties().intent 
+Intent() = Properties().intent
 
 Role() = Properties().role
 
-AccessType() = input.type 
+AccessType() = input.type
 
 DatasetTags() = input.details.metadata.dataset_tags
 

--- a/charts/m4d/files/opa-server/policy-lib/verify_correct_input.rego
+++ b/charts/m4d/files/opa-server/policy-lib/verify_correct_input.rego
@@ -8,8 +8,8 @@ incorrect_input[used_policy] {
    not verify_access_type
    used_policy := build_action_from_policies(build_policy_from_description("unknown access type"))
 } {
-    not verify_purpose
-    used_policy := build_action_from_policies(build_policy_from_description("unknown purpose"))
+    not verify_intent
+    used_policy := build_action_from_policies(build_policy_from_description("unknown intent"))
 } {
     not verify_role
     used_policy := build_action_from_policies(build_policy_from_description("unknown role"))

--- a/third_party/opa/data-and-policies/meshfordata-external-data/taxonomies.json
+++ b/third_party/opa/data-and-policies/meshfordata-external-data/taxonomies.json
@@ -1,7 +1,7 @@
 {
-    "DataIntents": ["audit&complience", "client Support", "marketing", "Fraud Detection", "Customer Behaviour Analysis"],
+    "Intents": ["audit&complience", "client Support", "marketing", "Fraud Detection", "Customer Behaviour Analysis"],
 
-    "DataRoles": ["Data Scientist", "Business Analyst", "hr", "management", "security"],
+    "Roles": ["Data Scientist", "Business Analyst", "hr", "management", "security"],
 
     "DataSensitivity": ["SPI", "SHI", "ECI", "Confidential"],
 

--- a/third_party/opa/data-and-policies/meshfordata-external-data/taxonomies.json
+++ b/third_party/opa/data-and-policies/meshfordata-external-data/taxonomies.json
@@ -1,5 +1,5 @@
 {
-    "DataPurposes": ["audit&complience", "client Support", "marketing", "Fraud Detection", "Customer Behaviour Analysis"],
+    "DataIntents": ["audit&complience", "client Support", "marketing", "Fraud Detection", "Customer Behaviour Analysis"],
 
     "DataRoles": ["Data Scientist", "Business Analyst", "hr", "management", "security"],
 

--- a/third_party/opa/data-and-policies/meshfordata-policy-lib/helper_functions.rego
+++ b/third_party/opa/data-and-policies/meshfordata-policy-lib/helper_functions.rego
@@ -40,8 +40,8 @@ column_has_tag(tag) {
 	compare_str(tag, input.details.metadata.components_metadata[_].tags[_])
 }
 
-check_purpose(purpose) {
-    compare_str(purpose, Purpose())
+check_intent(intent) {
+    compare_str(intent, Intent())
 }
 
 check_role(role) {

--- a/third_party/opa/data-and-policies/meshfordata-policy-lib/input_reader.rego
+++ b/third_party/opa/data-and-policies/meshfordata-policy-lib/input_reader.rego
@@ -1,6 +1,6 @@
 package data_policies
 
-#this file assumes input to be provided in specific format, in this case how data mesh provides it 
+#this file assumes input to be provided in specific format, in this case how data mesh provides it
 #similar file can be built for Egeria, at least for the metadata part, or any other catalog when we show how the input should be  parsed correctly
 
 #Example structure:
@@ -46,11 +46,11 @@ package data_policies
 # }
 Properties() = input.properties
 
-Purpose() = Properties().intent 
+Intent() = Properties().intent
 
 Role() = Properties().role
 
-AccessType() = input.type 
+AccessType() = input.type
 
 DatasetTags() = input.details.metadata.dataset_tags
 

--- a/third_party/opa/data-and-policies/meshfordata-policy-lib/taxonomies_unification.rego
+++ b/third_party/opa/data-and-policies/meshfordata-policy-lib/taxonomies_unification.rego
@@ -3,9 +3,9 @@ package data_policies
 #In data part we provide set of general and industry specific taxonomies, also the user can add more taxonomies specific for his needs.
 #Here is the place when for each category user chooses what taxonomies should be used
 
-Intents = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].DataIntents[_] }
+Intents = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].Intents[_] }
 
-Roles = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].DataRoles[_] } | { x | x = data["m4d-system"]["meshfordata-external-data"]["medical_taxonomies.json"].MedicalRoles[_] }
+Roles = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].Roles[_] } | { x | x = data["m4d-system"]["meshfordata-external-data"]["medical_taxonomies.json"].MedicalRoles[_] }
 
 Sensitivity = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].DataSensitivity[_] }
 

--- a/third_party/opa/data-and-policies/meshfordata-policy-lib/taxonomies_unification.rego
+++ b/third_party/opa/data-and-policies/meshfordata-policy-lib/taxonomies_unification.rego
@@ -3,7 +3,7 @@ package data_policies
 #In data part we provide set of general and industry specific taxonomies, also the user can add more taxonomies specific for his needs.
 #Here is the place when for each category user chooses what taxonomies should be used
 
-Purposes = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].DataPurposes[_] }
+Intents = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].DataIntents[_] }
 
 Roles = { x | x = data["m4d-system"]["meshfordata-external-data"]["taxonomies.json"].DataRoles[_] } | { x | x = data["m4d-system"]["meshfordata-external-data"]["medical_taxonomies.json"].MedicalRoles[_] }
 

--- a/third_party/opa/data-and-policies/meshfordata-policy-lib/taxonomies_verify.rego
+++ b/third_party/opa/data-and-policies/meshfordata-policy-lib/taxonomies_verify.rego
@@ -4,8 +4,8 @@ verify_access_type {
 		compare_str(AccessType(), AccessTypes[_])
 }
 
-verify_purpose {
-		compare_str(Purpose(), Purposes[_])
+verify_intent {
+		compare_str(Intent(), Intents[_])
 }
 
 verify_role {

--- a/third_party/opa/data-and-policies/meshfordata-policy-lib/verify_correct_input.rego
+++ b/third_party/opa/data-and-policies/meshfordata-policy-lib/verify_correct_input.rego
@@ -8,8 +8,8 @@ incorrect_input[used_policy] {
    not verify_access_type
    used_policy := build_action_from_policies(build_policy_from_description("unknown access type"))
 } {
-    not verify_purpose
-    used_policy := build_action_from_policies(build_policy_from_description("unknown purpose"))
+    not verify_intent
+    used_policy := build_action_from_policies(build_policy_from_description("unknown intent"))
 } {
     not verify_role
     used_policy := build_action_from_policies(build_policy_from_description("unknown role"))

--- a/third_party/opa/data-and-policies/user-created-policy-1/sample_policies.rego
+++ b/third_party/opa/data-and-policies/user-created-policy-1/sample_policies.rego
@@ -6,7 +6,7 @@ transform[action] {
 	dp.correct_input
     #user context and access type check
     dp.check_access_type([dp.AccessTypes.READ])
-	dp.check_purpose("Fraud Detection")
+	dp.check_intent("Fraud Detection")
 	dp.check_role("Data Scientist")
 	dp.dataset_has_tag("residency = Turkey")
 	dp.check_processingGeo_not("Turkey")
@@ -15,11 +15,11 @@ transform[action] {
 }
 
 deny[action] {
-	description = "Deny if role is not Data Scientist when purpose is Fraud Detection"
+	description = "Deny if role is not Data Scientist when intent is Fraud Detection"
 	dp.correct_input
     #user context and access type check
     dp.check_access_type([dp.AccessTypes.READ])
-	dp.check_purpose("Fraud Detection")
+	dp.check_intent("Fraud Detection")
 	dp.check_role_not("Data Scientist")
 	dp.dataset_has_tag("residency = Turkey")
     action = dp.build_deny_access_action(dp.build_policy_from_description(description))
@@ -30,7 +30,7 @@ deny[action] {
 	dp.correct_input
     #user context and access type check
     dp.check_access_type([dp.AccessTypes.READ])
-	dp.check_purpose("Customer Behaviour Analysis")
+	dp.check_intent("Customer Behaviour Analysis")
 	dp.check_role("Business Analyst")
 	dp.dataset_has_tag("residency = Turkey")
     dp.column_has_tag("Confidential")
@@ -38,11 +38,11 @@ deny[action] {
 }
 
 deny[action] {
-	description = "Deny if role is not Business Analyst when purpose is Customer Behaviour Analysis"
+	description = "Deny if role is not Business Analyst when intent is Customer Behaviour Analysis"
 	dp.correct_input
     #user context and access type check
     dp.check_access_type([dp.AccessTypes.READ])
-	dp.check_purpose("Customer Behaviour Analysis")
+	dp.check_intent("Customer Behaviour Analysis")
 	dp.check_role_not("Business Analyst")
 	dp.dataset_has_tag("residency = Turkey")
 	dp.check_processingGeo_not("Turkey")
@@ -51,11 +51,11 @@ deny[action] {
 
 
 deny[action] {
-	description = "Deny if role is Data Scientist and purpose is Fraud Detection but the processing geography is not Trukey"
+	description = "Deny if role is Data Scientist and intent is Fraud Detection but the processing geography is not Trukey"
 	dp.correct_input
     #user context and access type check
     dp.check_access_type([dp.AccessTypes.READ])
-	dp.check_purpose("Fraud Detection")
+	dp.check_intent("Fraud Detection")
 	dp.check_role_not("Data Scientist")
 	dp.dataset_has_tag("residency = Turkey")
 	dp.check_processingGeo_not("Turkey")


### PR DESCRIPTION
Since we are using the term "intent" instead of "purpose", this PR renames occurrences of "purpose" to "intent". 

Signed-off-by: rohithdv <rovallam@in.ibm.com>